### PR TITLE
Added support for MAKE environment variable

### DIFF
--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -111,8 +111,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   end
 
   defp build(config, task_args) do
-    exec      = System.get_env("MAKE") ||
-    Keyword.get(config, :make_executable, :default) |> os_specific_executable()
+    exec      = System.get_env("MAKE") || os_specific_executable(Keyword.get(config, :make_executable, :default))
     makefile  = Keyword.get(config, :make_makefile, :default)
     targets   = Keyword.get(config, :make_targets, [])
     env       = Keyword.get(config, :make_env, %{})

--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   end
 
   defp build(config, task_args) do
-    exec      = System.get_env("MAKE") |> sanitize_input() ||
+    exec      = System.get_env("MAKE") ||
     Keyword.get(config, :make_executable, :default) |> os_specific_executable()
     makefile  = Keyword.get(config, :make_makefile, :default)
     targets   = Keyword.get(config, :make_targets, [])
@@ -150,11 +150,6 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   defp find_executable(exec) do
     System.find_executable(exec) || Mix.raise("`#{exec}` " <> @exec_notfound_msg)
   end
-
-  defp sanitize_input(exec) when is_binary(exec) do
-    :binary.split(exec, " ") |> hd()
-  end
-  defp sanitize_input(_), do: nil
 
   defp raise_build_error(exec, exit_status, error_msg) do
     Mix.raise("Could not compile with `#{exec}` (exit status: #{exit_status}).\n" <> error_msg)

--- a/test/mix/tasks/compile.make_test.exs
+++ b/test/mix/tasks/compile.make_test.exs
@@ -6,11 +6,6 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
 
   @fixture_project Path.expand("../../fixtures/my_app", __DIR__)
 
-  @exec_notfound_msg """
-  `nonexistentmake` not found in the path. If you have set the MAKE environment variable,
-  please make sure it is correct.
-  """
-
   defmodule Sample do
     def project do
       [app: :sample,
@@ -27,7 +22,7 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
   test "running with a specific executable" do
     in_fixture fn ->
       with_project_config [make_executable: "nonexistentmake"], fn ->
-        assert_raise Mix.Error, @exec_notfound_msg, fn ->
+        assert_raise Mix.Error, ~r/not found in the path/, fn ->
           capture_io(fn -> run([]) end)
         end
       end
@@ -148,7 +143,7 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
     in_fixture fn ->
       System.put_env("MAKE", "nonexistentmake")
       with_project_config [], fn ->
-        assert_raise Mix.Error, @exec_notfound_msg, fn ->
+        assert_raise Mix.Error, ~r/not found in the path/, fn ->
           capture_io(fn -> run([]) end)
         end
       end
@@ -159,7 +154,7 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
     in_fixture fn ->
       System.put_env("MAKE", "nonexistentmake -f makefile")
       with_project_config [], fn ->
-        assert_raise Mix.Error, @exec_notfound_msg, fn ->
+        assert_raise Mix.Error, ~r/not found in the path/, fn ->
           capture_io(fn -> run([]) end)
         end
       end

--- a/test/mix/tasks/compile.make_test.exs
+++ b/test/mix/tasks/compile.make_test.exs
@@ -143,18 +143,18 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
     in_fixture fn ->
       System.put_env("MAKE", "nonexistentmake")
       with_project_config [], fn ->
-        assert_raise Mix.Error, ~r/not found in the path/, fn ->
+        assert_raise Mix.Error, ~r/`nonexistentmake` not found in the path/, fn ->
           capture_io(fn -> run([]) end)
         end
       end
     end
   end
 
-  test "user-defined executable with sanitized input" do
+  test "user-defined executable with no arguments allowed" do
     in_fixture fn ->
-      System.put_env("MAKE", "nonexistentmake -f makefile")
+      System.put_env("MAKE", "make -f makefile")
       with_project_config [], fn ->
-        assert_raise Mix.Error, ~r/not found in the path/, fn ->
+        assert_raise Mix.Error, ~r/`make -f makefile` not found in the path/, fn ->
           capture_io(fn -> run([]) end)
         end
       end


### PR DESCRIPTION
This allows for a user to choose what executable is used in the compilation by setting the MAKE environment variable.
In this case, the input is sanitized to only allow the command (any arguments are ignored), as recommended [here](https://github.com/elixir-lang/elixir/issues/4082#issuecomment-223659195). We could restrict it further by just allowing certain values. What do you think?