### PR TITLE
Use the absolute path for :make_cwd by default

### DIFF
--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -111,7 +111,12 @@ defmodule Mix.Tasks.Compile.ElixirMake do
     makefile  = Keyword.get(config, :make_makefile, :default)
     targets   = Keyword.get(config, :make_targets, [])
     env       = Keyword.get(config, :make_env, %{})
-    cwd       = Keyword.get(config, :make_cwd, ".")
+    # In OTP 19, Erlang's `open_port/2` ignores the current working
+    # directory when expanding relative paths. This means that `:make_cwd`
+    # must be an absolute path. This is a different behaviour from earlier
+    # OTP versions and appears to be a bug. It is being tracked at
+    # http://bugs.erlang.org/browse/ERL-175.
+    cwd       = Keyword.get(config, :make_cwd, File.cwd!())
     error_msg = Keyword.get(config, :make_error_message, :default) |> os_specific_error_msg()
 
     args = args_for_makefile(exec, makefile) ++ targets


### PR DESCRIPTION
A change occurred in OTP 19 (at least that's when I first saw it) that causes the current working directory that `make` is invoked in to not be set correctly. The error does not occur in OTP 18. This happens when `elixir_make` is being used to compile a dependency. The current working directory for `make` is incorrectly set to the main project's directory rather then `deps/project`. This causes the `Makefile` to not be found (or the wrong `Makefile` to be used if the main project has one).

Interestingly, the current working directory (as known by `File.cwd!()` is correct when `System.cmd/3` is called. One would think that changing to the `.` directory would be fine. However, it is not. Setting `:make_cwd` to the absolute path fixes the problem. That's what's done in this PR.

I am not happy with this PR since I believe that `elixir_make` is currently implemented correctly, but I submit it to get the discussion started. If I were to speculate, I'd guess that there's some caching of the current working directory happening internally that the OS isn't notified of before `make` is called. My hope is that someone here has come across this issue before. 