### PR TITLE
Allow `make_env/0` to be a function

### DIFF
--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -46,7 +46,9 @@ defmodule Mix.Tasks.Compile.ElixirMake do
       relative to the root of the project.
 
     * `:make_env` - (map of binary to binary) it's a map of extra environment
-      variables to be passed to `make`.
+      variables to be passed to `make`. You can also pass a function in here in 
+      case `make_env` needs access to things that are not available during project
+      setup; the function should return a map of binary to binary.
 
     * `:make_error_message` - (binary or `:default`) it's a custom error message
       that can be used to give instructions as of how to fix the error (e.g., it
@@ -118,6 +120,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
     makefile = Keyword.get(config, :make_makefile, :default)
     targets = Keyword.get(config, :make_targets, [])
     env = Keyword.get(config, :make_env, %{})
+    env = if is_function(env), do: env.(), else: env
     # In OTP 19, Erlang's `open_port/2` ignores the current working
     # directory when expanding relative paths. This means that `:make_cwd`
     # must be an absolute path. This is a different behaviour from earlier


### PR DESCRIPTION
See https://elixirforum.com/t/a-little-puzzle-involving-mix-elixir-make-and-paths/14534 and the associated code. With this patch, I can do

```
diff --git a/theapp/mix.exs b/theapp/mix.exs
index 602affd..c4b7539 100644
--- a/theapp/mix.exs
+++ b/theapp/mix.exs
@@ -7,7 +7,7 @@ defmodule Theapp.MixProject do
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
-      make_env: make_env(),
+      make_env: &make_env/0,
       compilers: Mix.compilers ++ [:elixir_make],
       deps: deps()
     ]
```

and stuff works. `make_env` is invoked very early, in the project setup, and all sorts of useful stuff isn't setup there; using `Mix.Project.build_path`, for example, gives bogus return values. By making the
function call lazy, the code is executed at a point where the Mix project has been configured, the `Mix.Project` functions (and, I guess, `Application` and `:code` functions as well) work as expected, so much more powerful stuff can be done in `make_env`. 