### PR TITLE
Don't clobber build artifacts with build_embedded

### DIFF
--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -116,8 +116,8 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   def run(args) do
     config = Mix.Project.config()
     Mix.shell().print_app()
+    Mix.Project.ensure_structure()
     build(config, args)
-    Mix.Project.build_structure()
     :ok
   end
 

--- a/test/fixtures/my_app/mix.exs
+++ b/test/fixtures/my_app/mix.exs
@@ -2,6 +2,6 @@ defmodule MyApp.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :my_app, version: "1.0.0"]
+    [app: :my_app, version: "1.0.0", compilers: [:elixir_make]]
   end
 end


### PR DESCRIPTION
Looks like `Mix.Project.build_structure` is currently being run twice:
[once before the build by Mix in `compile.all`][0], and once after the
build by elixir_make.

When `build_embedded: true`, this ends up [deleting any files][1] the
build may have added into `priv` in the build directory. Similar issues
were discussed earlier in elixir-lang/elixir#8878, and copying artifacts
into the build directory's copy of `priv` was suggested as a workaround,
however the current behaviour prevents that.

[0]: <https://github.com/elixir-lang/elixir/blob/v1.8.2/lib/mix/lib/mix/tasks/compile.all.ex#L20>
[1]: <https://github.com/elixir-lang/elixir/blob/v1.8.2/lib/mix/lib/mix/project.ex#L646>