### PR TITLE
Warn on paths that contain spaces

### DIFF
--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -186,6 +186,14 @@ defmodule Mix.Tasks.Compile.ElixirMake do
     error_msg = Keyword.get(config, :make_error_message, :default) |> os_specific_error_msg()
     custom_args = Keyword.get(config, :make_args, [])
 
+    if String.contains?(cwd, " ") do
+      IO.warn(
+        "the absolute path to the makefile for this project contains spaces. Make might " <>
+          "not work properly if spaces are present in the path. The absolute path is: " <>
+          inspect(cwd)
+      )
+    end
+
     base = exec |> Path.basename() |> Path.rootname()
     args = args_for_makefile(base, makefile) ++ targets ++ custom_args
 

--- a/test/mix/tasks/compile.make_test.exs
+++ b/test/mix/tasks/compile.make_test.exs
@@ -97,6 +97,22 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
     end)
   end
 
+  test "warns if the cwd contains a space" do
+    in_fixture(fn ->
+      File.mkdir_p!("subdir with spaces")
+
+      File.write!("subdir with spaces/Makefile", """
+      all:
+      \t@echo "subdir_with_spaces"
+      """)
+
+      with_project_config([make_cwd: "subdir with spaces"], fn ->
+        assert capture_io(:stderr, fn -> run([]) end) =~
+                 "the absolute path to the makefile for this project contains spaces."
+      end)
+    end)
+  end
+
   test "specifying env" do
     in_fixture(fn ->
       File.write!("Makefile", """


### PR DESCRIPTION
Closes #34.

If the path where the makefile is contains spaces, we emit a warning.