### PR TITLE
Add hexdoc link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # A Make compiler for Mix
 
 [![Build Status](https://github.com/elixir-lang/elixir_make/workflows/CI/badge.svg)](https://github.com/elixir-lang/elixir_make/actions)
+[![Hex version](https://img.shields.io/hexpm/v/elixir_make.svg "Hex version")](https://hex.pm/packages/elixir_make)
 
 This project provides a Mix compiler that makes it straight-forward to use makefiles in your Mix projects.
+
+## Documentation
+
+API documentation is available at [https://hexdocs.pm/elixir_make](https://hexdocs.pm/elixir_make)
 
 ## Usage
 


### PR DESCRIPTION
This PR is a minor improvement for README.md.

Currently README.md does not have a link to the documentation, which is unfriendly to the user.

As I scanned through some popular repos, some have a "Documentation" section like [Phoenix](https://github.com/phoenixframework/phoenix/tree/v1.5.9#documentation) and others have a badge to Hex.pm like [Nerves](https://github.com/nerves-project/nerves/blob/main/README.md). Why not have them both?

![Screen Shot 2021-06-03 at 7 35 08 PM](https://user-images.githubusercontent.com/7563926/120725234-80875c00-c4a3-11eb-96c0-84873a74ef90.png)
