### PR TITLE
Don't pass default Erlang environment variables into Make

### DIFF
--- a/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/tasks/compile.make.ex
@@ -326,7 +326,13 @@ defmodule Mix.Tasks.Compile.ElixirMake do
         # erlang.mk naming
         "ERTS_INCLUDE_DIR" => env("ERTS_INCLUDE_DIR", erts_include_dir),
         "ERL_INTERFACE_LIB_DIR" => env("ERL_INTERFACE_LIB_DIR", erl_ei_lib_dir),
-        "ERL_INTERFACE_INCLUDE_DIR" => env("ERL_INTERFACE_INCLUDE_DIR", erl_ei_include_dir)
+        "ERL_INTERFACE_INCLUDE_DIR" => env("ERL_INTERFACE_INCLUDE_DIR", erl_ei_include_dir),
+
+        # Disable default erlang values
+        "BINDIR" => nil,
+        "ROOTDIR" => nil,
+        "PROGNAME" => nil,
+        "EMU" => nil
       },
       default_env
     )


### PR DESCRIPTION
These values, specifically `BINDIR` are common in external `Makefiles`, for example the one in 
[WireGuard](https://github.com/WireGuard/wireguard-tools/blob/1fd95708391088742c139010cc6b821add941dec/src/Makefile#L9)'s Makefile.

This causes binaries to get installed `$ERTS_ROOT_DIR/bin`. This PR disables those environment variables 