### PR TITLE
Improve Precompiler

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -89,7 +89,7 @@ Another optional config key is `make_precompiler_priv_paths`. For example, say t
 
 By default, everything in `priv` will be included in the precompiled tar file. However, files in `assets` can be very large or platform-independent, therefore, we would like to only include the `nif.so` (`nif.dll`) file and everything in the `lib` directory in the precompiled tar file to reduce the footprint. In this case, we can set `make_precompiler_priv_paths` to `["nif.so", "nif.dll", "lib"]`.
 
-Of course, wildcards (`?`, `**`, `*`) are supported when specifiying files. For example, `["nif.*", "lib/*.so", "lib/*.dll"]` will include `nif.so` (Linux/macOS) or `nif.dll` (Windows), and `.so` or `.dll` files in the `lib` directory. 
+Of course, wildcards (`?`, `**`, `*`) are supported when specifiying files. For example, `["nif.*", "lib/*.so", "lib/*.dll", "lib/*.dylib"]` will include `nif.so` (Linux/macOS) or `nif.dll` (Windows), and `.so` or `.dll` files in the `lib` directory. 
 
 Directory structures and symbolic links are preserved.
 

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -492,31 +492,10 @@ defmodule CCPrecompiler do
 
   @impl ElixirMake.Precompiler
   def post_precompile() do
-    write_metadata_to_file()
-  end
-
-  defp write_metadata_to_file() do
-    app = Mix.Project.config()[:app]
-    version = Mix.Project.config()[:version]
-    nif_version = ElixirMake.Precompiler.current_nif_version()
-    cache_dir = ElixirMake.Precompiler.cache_dir()
-
-    with {:ok, target} <- current_target() do
-      archived_artefact_file =
-        ElixirMake.Artefact.archive_filename(app, version, nif_version, target)
-
-      metadata = %{
-        app: app,
-        cached_tar_gz: Path.join([cache_dir, archived_artefact_file]),
-        target: target,
-        targets: all_supported_targets(:fetch),
-        version: version
-      }
-
-      ElixirMake.Artefact.write_metadata(app, metadata)
-    end
-
-    :ok
+    # It's possible to do some post precompilation work
+    # in this optionall callback
+    # after all precompile targets are compiled.
+    Logger.debug("Post precompile")
   end
 end
 ```

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -38,6 +38,7 @@ def project do
     make_precompiler: CCPrecompiler,
     make_precompiled_url: "https://github.com/cocoa-xu/cc_precompiler_example/releases/download/v#{@version}/@{artefact_filename}",
     make_nif_filename: "nif",
+    make_precompiler_priv_paths: ["nif.*"]
     # ...
   ]
 end
@@ -48,6 +49,49 @@ Another required field is `make_precompiled_url`. It is a URL template to the ar
 `@{artefact_filename}` in the URL template string will be replaced by corresponding artefact filenames when fetching them. For example, `cc_precompiler_example-nif-2.16-x86_64-linux-gnu-0.1.0.tar.gz`.
 
 Note that there is an optional config key for elixir_make, `make_nif_filename`. If the name (file extension does not count) of the shared library is different from your app's name, then `make_nif_filename` should be set. For example, if the app name is `"cc_precompiler_example"` while the name shared library is `"nif.so"` (or `"nif.dll"` on windows), then `make_nif_filename` should be set as `"nif"`.
+
+Another optional config key is `make_precompiler_priv_paths`. For example, say the priv directory is organised as follows in Linux, macOS and Windows respectively,
+
+```
+# Linux
+.
+├── assets
+│   ├── model.onnx
+│   └── data.json
+├── lib
+│   ├── libpriv1.so
+│   ├── libpriv2.so
+│   └── libpriv3.so
+└── nif.so
+
+# macOS
+.
+├── assets
+│   ├── model.onnx
+│   └── data.json
+├── lib
+│   ├── libpriv1.dylib
+│   ├── libpriv2.dylib
+│   └── libpriv3.dylib
+└── nif.so
+
+# Windows
+.
+├── assets
+│   ├── model.onnx
+│   └── data.json
+├── lib
+│   ├── libpriv1.dll
+│   ├── libpriv2.dll
+│   └── libpriv3.dll
+└── nif.dll
+```
+
+By default, everything in `priv` will be included in the precompiled tar file. However, files in `assets` can be very large or platform-independent, therefore, we would like to only include the `nif.so` (`nif.dll`) file and everything in the `lib` directory in the precompiled tar file to reduce the footprint. In this case, we can set `make_precompiler_priv_paths` to `["nif.so", "nif.dll", "lib"]`.
+
+Of course, wildcards (`?`, `**`, `*`) are supported when specifiying files. For example, `["nif.*", "lib/*.so", "lib/*.dll"]` will include `nif.so` (Linux/macOS) or `nif.dll` (Windows), and `.so` or `.dll` files in the `lib` directory. 
+
+Directory structures and symbolic links are preserved.
 
 ### (Optional) Test the NIF code locally
 

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -50,7 +50,7 @@ Another required field is `make_precompiled_url`. It is a URL template to the ar
 
 Note that there is an optional config key for elixir_make, `make_nif_filename`. If the name (file extension does not count) of the shared library is different from your app's name, then `make_nif_filename` should be set. For example, if the app name is `"cc_precompiler_example"` while the name shared library is `"nif.so"` (or `"nif.dll"` on windows), then `make_nif_filename` should be set as `"nif"`.
 
-Another optional config key is `make_precompiler_priv_paths`. For example, say the priv directory is organised as follows in Linux, macOS and Windows respectively,
+Another optional config key is `make_precompiler_priv_paths`. For example, say the `priv` directory is organised as follows in Linux, macOS and Windows respectively,
 
 ```
 # Linux

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -370,10 +370,8 @@ defmodule ElixirMake.Artefact do
                            # A little hack to use cacerts.pem in CAStore
                            Path.join([Path.dirname(Mix.ProjectStack.project_file()), "deps/castore/priv/cacerts.pem"]),
 
-                           # Populated if hex package certfi is configured
-                           if(Code.ensure_loaded?(:certifi),
-                             do: :certifi.cacertfile() |> List.to_string()
-                           ),
+                           # A little hack to use cacerts.pem in :certfi
+                           Path.join([Path.dirname(Mix.ProjectStack.project_file()), "deps/certfi/priv/cacerts.pem"]),
 
                            # Debian/Ubuntu/Gentoo etc.
                            "/etc/ssl/certs/ca-certificates.crt",
@@ -424,11 +422,9 @@ defmodule ElixirMake.Artefact do
        be automatically detected after recompilation.
 
     3. Specify the location of a certificate trust store
-       by configuring it in `config.exs`:
+       by configuring it in environment variable:
 
-         config :elixir_make,
-           cacertfile: "/path/to/cacertfile",
-           ...
+         export ELIXIR_MAKE_CACERT="/path/to/cacerts.pem"
     """
     ""
   end

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -125,7 +125,8 @@ defmodule ElixirMake.Artefact do
           {:ok, {algo, hash}}
 
         :error ->
-          {:error, "precompiled tar file does not exist in the checksum file, `checksum-#{app}.exs`."}
+          {:error,
+           "precompiled tar file does not exist in the checksum file, `checksum-#{app}.exs`."}
       end
     else
       {:error, "missing checksum file `checksum-#{app}.exs`"}

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -216,7 +216,9 @@ defmodule ElixirMake.Artefact do
     nif_version = ElixirMake.Precompiler.current_nif_version()
 
     Enum.map(targets, fn target ->
-      archive_filename = ElixirMake.Precompiler.archive_filename(app, version, nif_version, target)
+      archive_filename =
+        ElixirMake.Precompiler.archive_filename(app, version, nif_version, target)
+
       {target, String.replace(url_template, "@{artefact_filename}", archive_filename)}
     end)
   end

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -304,10 +304,10 @@ defmodule ElixirMake.Artefact do
                                    "deps/castore/priv/cacerts.pem"
                                  ]),
 
-                                 # A little hack to use cacerts.pem in :certfi
+                                 # A little hack to use cacerts.pem in :certifi
                                  Path.join([
                                    Path.dirname(Mix.ProjectStack.project_file()),
-                                   "deps/certfi/priv/cacerts.pem"
+                                   "deps/certifi/priv/cacerts.pem"
                                  ])
                                ]
                              else

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -175,8 +175,9 @@ defmodule Mix.Tasks.Compile.ElixirMake do
       {:ok, target, url} ->
         cache_dir = Precompiler.cache_dir()
 
-        app = Mix.Project.config()[:app]
-        version = Mix.Project.config()[:version]
+        config = Mix.Project.config()
+        app = config[:app]
+        version = config[:version]
         nif_version = Precompiler.current_nif_version()
         archived_filename = Artefact.archive_filename(app, version, nif_version, target)
 
@@ -199,17 +200,22 @@ defmodule Mix.Tasks.Compile.ElixirMake do
                     :ok
 
                   {:error, term} ->
-                    {:error, "cannot restore nif from cache: #{inspect(term)}"}
+                    msg = "cannot restore nif from cache: #{inspect(term)}"
+                    Mix.shell().error(msg)
+                    {:error, msg}
                 end
 
               {:error, reason} ->
-                {:error, "cache file integrity check failed: #{reason}"}
+                msg = "cache file integrity check failed: #{reason}"
+                Mix.shell().error(msg)
+                {:error, msg}
             end
 
           false ->
             Mix.shell().error("""
             precompiled tar file does not exist or cannot download, attempting to build from source...
             """)
+
             precompiler.build_native(args)
         end
 

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -186,9 +186,9 @@ defmodule Mix.Tasks.Compile.ElixirMake do
           archived_fullpath = Path.join([cache_dir, archived_filename])
 
           with false <- File.exists?(archived_fullpath),
-              :ok <- File.mkdir_p(cache_dir),
-              {:ok, archived_data} <- Artefact.download_nif_artefact(url),
-              :ok <- File.write(archived_fullpath, archived_data) do
+               :ok <- File.mkdir_p(cache_dir),
+               {:ok, archived_data} <- Artefact.download_nif_artefact(url),
+               :ok <- File.write(archived_fullpath, archived_data) do
             Mix.shell().info("NIF cached at #{archived_fullpath} and extracted to #{app_priv}")
           end
 
@@ -226,6 +226,5 @@ defmodule Mix.Tasks.Compile.ElixirMake do
       :ok ->
         :ok
     end
-
   end
 end

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
 
       true ->
         nif_filename = config[:make_nif_filename] || "#{app}"
-        priv_dir = ElixirMake.Artefact.app_priv(app)
+        priv_dir = ElixirMake.Precompiler.app_priv(app)
 
         load_path =
           case :os.type() do
@@ -180,9 +180,9 @@ defmodule Mix.Tasks.Compile.ElixirMake do
 
           version = config[:version]
           nif_version = Precompiler.current_nif_version()
-          archived_filename = Artefact.archive_filename(app, version, nif_version, target)
+          archived_filename = Precompiler.archive_filename(app, version, nif_version, target)
 
-          app_priv = Artefact.app_priv(app)
+          app_priv = Precompiler.app_priv(app)
           archived_fullpath = Path.join([cache_dir, archived_filename])
 
           with false <- File.exists?(archived_fullpath),

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
         with false <- File.exists?(load_path),
              {:error, precomp_error} <- download_or_reuse_or_build_nif(precompiler, args) do
           message = """
-          Error while downloading precompiled NIF: #{precomp_error}.
+          Error while installing precompiled NIF: #{precomp_error}.
 
           You can force the project to build from scratch with:
 
@@ -207,12 +207,14 @@ defmodule Mix.Tasks.Compile.ElixirMake do
             end
 
           false ->
-            {:error, "cache file does not exist or cannot download"}
+            Mix.shell().error("""
+            precompiled tar file does not exist or cannot download, attempting to build from source...
+            """)
+            precompiler.build_native(args)
         end
 
       {:error, msg} ->
-        Mix.shell().error(msg)
-        Mix.shell().info("Attempting to build from scratch...")
+        Mix.shell().error(msg <> " attempting to build from source...")
         precompiler.build_native(args)
     end
   end

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -139,14 +139,12 @@ defmodule Mix.Tasks.Compile.ElixirMake do
         with false <- File.exists?(load_path),
              {:error, precomp_error} <- download_or_reuse_or_build_nif(precompiler, args) do
           message = """
-          Error while installing precompiled NIF: #{precomp_error}.
-
-          You can force the project to build from scratch with:
-
-              mix elixir_make.precompile
+          Error happened while installing #{app} from precompiled binary: #{precomp_error}.
+          Now fallback to compile #{app} from source...
           """
 
-          Mix.raise(message)
+          Mix.shell().error(message)
+          precompiler.build_native(args)
         else
           _ -> {:ok, []}
         end
@@ -155,6 +153,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
 
   # This is called by Elixir when `mix clean` is run and `:elixir_make` is in
   # the list of compilers.
+  @spec clean :: nil | :ok
   def clean() do
     config = Mix.Project.config()
     {clean_targets, config} = Keyword.pop(config, :make_clean)
@@ -171,57 +170,62 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   end
 
   defp download_or_reuse_or_build_nif(precompiler, args) do
-    case Artefact.current_target_nif_url(precompiler) do
-      {:ok, target, url} ->
-        cache_dir = Precompiler.cache_dir()
+    config = Mix.Project.config()
+    app = config[:app]
 
-        config = Mix.Project.config()
-        app = config[:app]
-        version = config[:version]
-        nif_version = Precompiler.current_nif_version()
-        archived_filename = Artefact.archive_filename(app, version, nif_version, target)
+    status =
+      case Artefact.current_target_nif_url(precompiler) do
+        {:ok, target, url} ->
+          cache_dir = Precompiler.cache_dir()
 
-        app_priv = Artefact.app_priv(app)
-        archived_fullpath = Path.join([cache_dir, archived_filename])
+          version = config[:version]
+          nif_version = Precompiler.current_nif_version()
+          archived_filename = Artefact.archive_filename(app, version, nif_version, target)
 
-        with false <- File.exists?(archived_fullpath),
-             :ok <- File.mkdir_p(cache_dir),
-             {:ok, archived_data} <- Artefact.download_nif_artefact(url),
-             :ok <- File.write(archived_fullpath, archived_data) do
-          Mix.shell().info("NIF cached at #{archived_fullpath} and extracted to #{app_priv}")
-        end
+          app_priv = Artefact.app_priv(app)
+          archived_fullpath = Path.join([cache_dir, archived_filename])
 
-        case File.exists?(archived_fullpath) do
-          true ->
-            case Artefact.check_file_integrity(archived_fullpath, app) do
-              :ok ->
-                case Artefact.restore_nif_file(archived_fullpath, app) do
-                  :ok ->
-                    :ok
+          with false <- File.exists?(archived_fullpath),
+              :ok <- File.mkdir_p(cache_dir),
+              {:ok, archived_data} <- Artefact.download_nif_artefact(url),
+              :ok <- File.write(archived_fullpath, archived_data) do
+            Mix.shell().info("NIF cached at #{archived_fullpath} and extracted to #{app_priv}")
+          end
 
-                  {:error, term} ->
-                    msg = "cannot restore nif from cache: #{inspect(term)}"
-                    Mix.shell().error(msg)
-                    {:error, msg}
-                end
+          case File.exists?(archived_fullpath) do
+            true ->
+              case Artefact.check_file_integrity(archived_fullpath, app) do
+                :ok ->
+                  case Artefact.restore_nif_file(archived_fullpath, app) do
+                    :ok ->
+                      :ok
 
-              {:error, reason} ->
-                msg = "cache file integrity check failed: #{reason}"
-                Mix.shell().error(msg)
-                {:error, msg}
-            end
+                    {:error, term} ->
+                      {:error, "cannot restore nif from cache: #{inspect(term)}"}
+                  end
 
-          false ->
-            Mix.shell().error("""
-            precompiled tar file does not exist or cannot download, attempting to build from source...
-            """)
+                {:error, reason} ->
+                  {:error, "cache file integrity check failed: #{reason}"}
+              end
 
-            precompiler.build_native(args)
-        end
+            false ->
+              {:error, "precompiled tar file does not exist or cannot download"}
+          end
 
-      {:error, msg} ->
-        Mix.shell().error(msg <> " attempting to build from source...")
+        {:error, msg} ->
+          {:error, msg}
+      end
+
+    # whenever we fail to use the precompiled one
+    # we should fallback to building from source.
+    case status do
+      {:error, reason} ->
+        Mix.shell().error(reason <> "; fallback to building #{app} from source...")
         precompiler.build_native(args)
+
+      :ok ->
+        :ok
     end
+
   end
 end

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -22,7 +22,6 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
 
   @switches [
     all: :boolean,
-    dep: :string,
     only_local: :boolean,
     print: :boolean,
     ignore_unavailable: :boolean
@@ -39,16 +38,6 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
         )
 
     {options, _args} = OptionParser.parse!(flags, strict: @switches)
-
-    dep = options[:dep]
-    if dep do
-      dep_config =
-        Enum.find(config[:deps], fn dep_entry ->
-          elem(dep_entry, 0) == dep
-        end)
-      IO.inspect(dep_config)
-      raise RuntimeError, "dep_config"
-    end
 
     urls =
       cond do

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
 
   @switches [
     all: :boolean,
+    dep: :string,
     only_local: :boolean,
     print: :boolean,
     ignore_unavailable: :boolean
@@ -38,6 +39,16 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
         )
 
     {options, _args} = OptionParser.parse!(flags, strict: @switches)
+
+    dep = options[:dep]
+    if dep do
+      dep_config =
+        Enum.find(config[:deps], fn dep_entry ->
+          elem(dep_entry, 0) == dep
+        end)
+      IO.inspect(dep_config)
+      raise RuntimeError, "dep_config"
+    end
 
     urls =
       cond do

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
     config = Mix.Project.config()
 
     precompiler =
-      config[:precompiler] ||
+      config[:make_precompiler] ||
         Mix.raise(
           ":make_precompiler project configuration is required when using elixir_make.checksum"
         )

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
     nif_version = Precompiler.current_nif_version()
 
     precompiler =
-      config[:precompiler] ||
+      config[:make_precompiler] ||
         Mix.raise(
           ":make_precompiler project configuration is required when using elixir_make.precompile"
         )

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
   def run(args) do
     config = Mix.Project.config()
     app = config[:app]
-    paths = config[:make_precompiler_priv_paths] || ['.']
+    paths = config[:make_precompiler_priv_paths] || ["."]
     version = config[:version]
     nif_version = Precompiler.current_nif_version()
 

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -39,7 +39,14 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
         {_archive_full_path, archived_filename, checksum_algo, checksum} =
           case precompiler.precompile(args, target) do
             :ok ->
-              Artefact.create_precompiled_archive(app, version, nif_version, target, cache_dir, paths)
+              Artefact.create_precompiled_archive(
+                app,
+                version,
+                nif_version,
+                target,
+                cache_dir,
+                paths
+              )
 
             {:error, msg} ->
               Mix.raise(msg)

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
         {_archive_full_path, archived_filename, checksum_algo, checksum} =
           case precompiler.precompile(args, target) do
             :ok ->
-              Artefact.create_precompiled_archive(
+              Precompiler.create_precompiled_archive(
                 app,
                 version,
                 nif_version,
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
     end
 
     with {:ok, target} <- precompiler.current_target() do
-      archived_filename = Artefact.archive_filename(app, version, nif_version, target)
+      archived_filename = Precompiler.archive_filename(app, version, nif_version, target)
       archived_fullpath = Path.join([cache_dir, archived_filename])
       Artefact.restore_nif_file(archived_fullpath, app)
     end

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -15,6 +15,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
   def run(args) do
     config = Mix.Project.config()
     app = config[:app]
+    paths = config[:make_precompiler_priv_paths] || ['.']
     version = config[:version]
     nif_version = Precompiler.current_nif_version()
 
@@ -38,7 +39,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
         {_archive_full_path, archived_filename, checksum_algo, checksum} =
           case precompiler.precompile(args, target) do
             :ok ->
-              Artefact.create_precompiled_archive(app, version, nif_version, target, cache_dir)
+              Artefact.create_precompiled_archive(app, version, nif_version, target, cache_dir, paths)
 
             {:error, msg} ->
               Mix.raise(msg)

--- a/test/fixtures/my_app/mix.exs
+++ b/test/fixtures/my_app/mix.exs
@@ -5,3 +5,22 @@ defmodule MyApp.Mixfile do
     [app: :my_app, version: "1.0.0", compilers: [:elixir_make]]
   end
 end
+
+defmodule MyApp.Precompiler do
+  @behaviour ElixirMake.Precompiler
+
+  @impl true
+  def current_target, do: "target"
+
+  @impl true
+  def all_supported_targets(_), do: ["target"]
+
+  @impl true
+  def build_native(args), do: ElixirMake.Compiler.compile(args)
+
+  @impl true
+  def precompile(args, _target) do
+    ElixirMake.Compiler.compile(args)
+    :ok
+  end
+end

--- a/test/mix/tasks/compile.make_test.exs
+++ b/test/mix/tasks/compile.make_test.exs
@@ -312,6 +312,64 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
     end)
   end
 
+  test "precompiler should only include specified files" do
+    in_fixture(fn ->
+      include_this = "include_this"
+      build_file = "build_file"
+
+      precompile_config = [
+        make_precompiler: MyApp.Precompiler,
+        make_precompiler_priv_paths: [include_this, build_file],
+        make_force_build: true
+      ]
+
+      cache_dir = "./cache"
+      File.mkdir_p!(cache_dir)
+      System.put_env("ELIXIR_MAKE_CACHE_DIR", cache_dir)
+
+      File.mkdir!("priv")
+      priv_dir = "./_build/test/lib/my_app/priv"
+      build_file_path = Path.join([priv_dir, build_file])
+      include_this_path = Path.join([priv_dir, include_this])
+      exclude_this_path = Path.join([priv_dir, "exclude_this"])
+
+      File.write!("Makefile", """
+      all:
+      \ttouch #{build_file_path}
+      \ttouch #{include_this_path}
+      \ttouch #{exclude_this_path}
+      """)
+
+      with_project_config(precompile_config, fn ->
+        refute File.exists?(build_file_path)
+        refute File.exists?(include_this_path)
+        refute File.exists?(exclude_this_path)
+
+        capture_io(fn ->
+          Mix.Tasks.ElixirMake.Precompile.run([])
+        end)
+
+        assert File.exists?(build_file_path)
+        assert File.exists?(include_this_path)
+        assert File.exists?(exclude_this_path)
+
+        precompiled_tar_file =
+          "./cache/my_app-nif-#{ElixirMake.Precompiler.current_nif_version()}-target-1.0.0.tar.gz"
+
+        extract_to = "./cache/priv"
+        :erl_tar.extract(precompiled_tar_file, [:compressed, {:cwd, extract_to}])
+
+        build_file_path = Path.join([extract_to, build_file])
+        include_this_path = Path.join([extract_to, include_this])
+        exclude_this_path = Path.join([extract_to, "exclude_this"])
+
+        assert File.exists?(build_file_path)
+        assert File.exists?(include_this_path)
+        assert !File.exists?(exclude_this_path)
+      end)
+    end)
+  end
+
   defp in_fixture(fun) do
     File.cd!(@fixture_project, fun)
   end


### PR DESCRIPTION
- detect cacerts.pem in `CAStore` and `:certifi`
- display warnings instead of raise if there is no cacertfile (e.g., on windows)
- build from source if cannot download the precompiled tar file
- wildcard files specified in `:make_precompiler_priv_paths`
  
  Say the `priv` directory of `:app` is organised as follows,

  ```
  .
  ├── assets
  │   ├── model.onnx
  │   └── data.json
  ├── lib
  │   └── libpriv.so
  └── nif.so
  ```

  and the library developer only wants to compress `nif.so` and everything under `lib` directory into the precompiled tar file because files in `assets` could be very large or platform-independent. Then the library developer can specify `:make_precompiler_priv_paths` in the `project`:

  ```elixir
  def project do
    [
      # ...
      make_precompiler_priv_paths: ["lib", "nif.so"],
      # ...
    ]
  end
  ```

However, there is a problem in the following situation:

Say we are developing `:app`, and it has three dependencies: `:foo`, `:bar` and `:baz`. All these dependencies use `:elixir_make` and they all have precompiled binaries for the current target.

```elixir
def deps do
  [
    {:foo, "~> 0.1"},
    {:bar, "~> 0.2", github: "user/bar"},
    {:baz, "~> 0.3", path: "../baz"}
  ]
end
```

The problem is that the `checksum-[foo|bar|baz].exs` files are only tracked in their hex packages. While we can download and extract everything we need for `:bar` and `:baz`, we cannot check their integrities.

There are three solutions (that I can think of) to solve this problem:

1. If the file integrity cannot be verified (missing checksum-*.exs), then we attempt to compile `:bar` and `:baz` from source.
2. (Optionally) ask the library maintainers to include their `checksum-*.exs` file in the GitHub release. 
    If we can download the checksum file from GitHub, and verify the downloaded tar file, `:app` can use the precompiled binaries of `:bar` and `:baz`.
3. Compile `:bar` and `:baz` from source because they are not hex dependencies.

Solution No.3 seems to be the simplest way, but I'd like to know your thoughts @josevalim, and I'm not sure if there is any API in `Mix` that can tell me whether the current app is pulled from hex or not...

Also, if anyone has a better idea for this, please join the discussion here. :)