### PR TITLE
Always delete the `priv` dir after precompilation is done

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -376,7 +376,7 @@ defmodule ElixirMake.Artefact do
   end
 
   defp warning_if_no_cacertfile!(nil) do
-    Logger.warn("""
+    Mix.shell().error("""
     No certificate trust store was found.
 
     Tried looking for: #{inspect(@certificate_locations)}

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -376,7 +376,7 @@ defmodule ElixirMake.Artefact do
   end
 
   defp warning_if_no_cacertfile!(nil) do
-    Logger.warning("""
+    Logger.warn("""
     No certificate trust store was found.
 
     Tried looking for: #{inspect(@certificate_locations)}

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -15,34 +15,39 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
   def run(args) do
     config = Mix.Project.config()
 
-    precompiler =
-      config[:make_precompiler] ||
-        Mix.raise(
-          ":make_precompiler project configuration is required when using elixir_make.precompile"
-        )
+    try do
+      precompiler =
+        config[:make_precompiler] ||
+          Mix.raise(
+            ":make_precompiler project configuration is required when using elixir_make.precompile"
+          )
 
-    paths = config[:make_precompiler_priv_paths] || ["."]
-    targets = precompiler.all_supported_targets(:compile)
+      paths = config[:make_precompiler_priv_paths] || ["."]
+      targets = precompiler.all_supported_targets(:compile)
 
-    precompiled_artefacts =
-      Enum.map(targets, fn target ->
-        {archived_filename, checksum_algo, checksum} =
-          case precompiler.precompile(args, target) do
-            :ok -> Artefact.create_precompiled_archive(config, target, paths)
-            {:error, msg} -> Mix.raise(msg)
-          end
+      precompiled_artefacts =
+        Enum.map(targets, fn target ->
+          {archived_filename, checksum_algo, checksum} =
+            case precompiler.precompile(args, target) do
+              :ok -> Artefact.create_precompiled_archive(config, target, paths)
+              {:error, msg} -> Mix.raise(msg)
+            end
 
-        %{path: archived_filename, checksum_algo: checksum_algo, checksum: checksum}
-      end)
+          %{path: archived_filename, checksum_algo: checksum_algo, checksum: checksum}
+        end)
 
-    Artefact.write_checksum!(precompiled_artefacts)
+      Artefact.write_checksum!(precompiled_artefacts)
 
-    if function_exported?(precompiler, :post_precompile, 0) do
-      precompiler.post_precompile()
-    else
-      :ok
+      if function_exported?(precompiler, :post_precompile, 0) do
+        precompiler.post_precompile()
+      else
+        :ok
+      end
+
+      Mix.Project.build_structure()
+    after
+      app_priv = Path.join(Mix.Project.app_path(config), "priv")
+      File.rm!(app_priv)
     end
-
-    Mix.Project.build_structure()
   end
 end

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -43,8 +43,6 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
       else
         :ok
       end
-
-      Mix.Project.build_structure()
     after
       app_priv = Path.join(Mix.Project.app_path(config), "priv")
 

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
   @impl true
   def run(args) do
     config = Mix.Project.config()
+    paths = config[:make_precompiler_priv_paths] || ["."]
 
     try do
       precompiler =
@@ -22,7 +23,6 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
             ":make_precompiler project configuration is required when using elixir_make.precompile"
           )
 
-      paths = config[:make_precompiler_priv_paths] || ["."]
       targets = precompiler.all_supported_targets(:compile)
 
       precompiled_artefacts =
@@ -47,7 +47,11 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
       Mix.Project.build_structure()
     after
       app_priv = Path.join(Mix.Project.app_path(config), "priv")
-      File.rm!(app_priv)
+
+      for include <- paths,
+          file <- Path.wildcard(Path.join(app_priv, include)) do
+        File.rm_rf!(file)
+      end
     end
   end
 end

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
 
       for include <- paths,
           file <- Path.wildcard(Path.join(app_priv, include)) do
-        File.rm_rf!(file)
+        File.rm_rf(file)
       end
     end
   end

--- a/test/mix/tasks/compile.make_test.exs
+++ b/test/mix/tasks/compile.make_test.exs
@@ -356,18 +356,12 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
           Mix.Tasks.ElixirMake.Precompile.run([])
         end)
 
-        assert File.exists?(build_file_path)
-        assert Enum.all?(include_this_path, &File.exists?/1)
-        assert File.exists?(exclude_this_path)
-        assert File.dir?(lib_dir_path)
-        assert :ok == elem(File.read_link(symlink_to_lib_dir_path), 0)
-
         precompiled_tar_file =
           "./cache/my_app-nif-#{:erlang.system_info(:nif_version)}-target-1.0.0.tar.gz"
 
         extract_to = "./cache/priv"
         File.rm_rf(extract_to)
-        :erl_tar.extract(precompiled_tar_file, [:compressed, {:cwd, extract_to}])
+        :ok = :erl_tar.extract(precompiled_tar_file, [:compressed, {:cwd, extract_to}])
 
         build_file_path = Path.join([extract_to, build_file])
         include_this_path = Enum.map(include_this, fn file -> Path.join([extract_to, file]) end)


### PR DESCRIPTION
Hi, we need to always delete the `priv` directory after the precompilation task is done. Otherwise, the `nif.so` file will be the one built for the last target.

For example, say we are precompiling for targets `["x86_64-linux-gnu", "aarch64-linux-gnu"]` on an `x86_64` machine,  then after the precompilation task, the `nif.so` file in the `priv` directory will correspond to `aarch64-linux-gnu`.

And currently, we are deciding whether to restore from the archive based on the existence of the `nif.so` file, if it exists, `elixir_make` will not restore the correct one from the archive.

Therefore, the fix is to always delete the ~~`priv` dir~~ files specified in `make_precompiler_priv_paths` after the precompilation task.