### PR TITLE
`:erl_tar.extract/2` expects `{:binary, contents}` when extracting from memory

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -103,7 +103,7 @@ defmodule ElixirMake.Artefact do
 
         case checksum(basename, contents) do
           %Artefact{checksum: ^checksum, checksum_algo: ^algo} ->
-            case :erl_tar.extract(contents, [:compressed, {:cwd, app_priv}]) do
+            case :erl_tar.extract({:binary, contents}, [:compressed, {:cwd, app_priv}]) do
               :ok ->
                 :ok
 


### PR DESCRIPTION
```
extract(Open :: open_type(), Opts :: [extract_opt()]) ->
           {ok, [{string(), binary()}]} | {error, term()} | ok
```

where `open_type()` is
```
open_type() =
    file:filename_all() |
    {binary, binary()} |
    {file, file:io_device()}
```

Reference: https://www.erlang.org/docs/25/man/erl_tar.html#extract-2