### PR TITLE
Recover from unavailable targets

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -38,8 +38,7 @@ def project do
     make_precompiler: {:nif, CCPrecompiler},
     make_precompiler_url: "https://github.com/cocoa-xu/cc_precompiler_example/releases/download/v#{@version}/@{artefact_filename}",
     make_precompiler_filename: "nif",
-    make_precompiler_priv_paths: ["nif.*"],
-    make_precompiler_unavailable_target: :compile,
+    make_precompiler_priv_paths: ["nif.*"]
     # ...
   ]
 end
@@ -52,10 +51,6 @@ Another required field is `make_precompiler_url`. It is a URL template to the ar
 Note that there is an optional config key for elixir_make, `make_precompiler_filename`. If the name (file extension does not count) of the shared library is different from your app's name, then `make_precompiler_filename` should be set. For example, if the app name is `"cc_precompiler_example"` while the name shared library is `"nif.so"` (or `"nif.dll"` on windows), then `make_precompiler_filename` should be set as `"nif"`.
 
 Another optional config key is `make_precompiler_priv_paths`. For example, say the `priv` directory is organised as follows in Linux, macOS and Windows respectively,
-
-Also, you can specify how to recover from unavailable targets using the `make_precompiler_unavailable_target` config key. Allowed values are `:compile` and `:ignore`. Defaults to `:compile`.
-
-It is also possible to pass in a 2-arity function to `make_precompiler_unavailable_target`: the first argument is the triplet of the unavailable target, and the second argument is a list that contains all available targets given by the precompiler.
 
 ```
 # Linux

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -38,7 +38,8 @@ def project do
     make_precompiler: {:nif, CCPrecompiler},
     make_precompiler_url: "https://github.com/cocoa-xu/cc_precompiler_example/releases/download/v#{@version}/@{artefact_filename}",
     make_precompiler_filename: "nif",
-    make_precompiler_priv_paths: ["nif.*"]
+    make_precompiler_priv_paths: ["nif.*"],
+    make_precompiler_unavailable_target: :compile,
     # ...
   ]
 end
@@ -51,6 +52,10 @@ Another required field is `make_precompiler_url`. It is a URL template to the ar
 Note that there is an optional config key for elixir_make, `make_precompiler_filename`. If the name (file extension does not count) of the shared library is different from your app's name, then `make_precompiler_filename` should be set. For example, if the app name is `"cc_precompiler_example"` while the name shared library is `"nif.so"` (or `"nif.dll"` on windows), then `make_precompiler_filename` should be set as `"nif"`.
 
 Another optional config key is `make_precompiler_priv_paths`. For example, say the `priv` directory is organised as follows in Linux, macOS and Windows respectively,
+
+Also, you can specify how to recover from unavailable targets using the `make_precompiler_unavailable_target` config key. Allowed values are `:compile` and `:ignore`. Defaults to `:compile`.
+
+It is also possible to pass in a 2-arity function to `make_precompiler_unavailable_target`: the first argument is the triplet of the unavailable target, and the second argument is a list that contains all available targets given by the precompiler.
 
 ```
 # Linux

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -173,7 +173,8 @@ defmodule ElixirMake.Artefact do
             available_targets = Enum.map(available_urls, fn {target, _url} -> target end)
 
             {:error,
-             "cannot find download url for current target `#{inspect(current_target)}`. Available targets are: #{inspect(available_targets)}"}
+             {:unavailable_target, current_target, available_targets,
+              "cannot find download url for current target `#{inspect(current_target)}`. Available targets are: #{inspect(available_targets)}"}}
         end
 
       {:error, msg} ->

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -173,7 +173,7 @@ defmodule ElixirMake.Artefact do
             available_targets = Enum.map(available_urls, fn {target, _url} -> target end)
 
             {:error,
-             {:unavailable_target, current_target, available_targets,
+             {:unavailable_target, current_target,
               "cannot find download url for current target `#{inspect(current_target)}`. Available targets are: #{inspect(available_targets)}"}}
         end
 

--- a/lib/elixir_make/precompiler.ex
+++ b/lib/elixir_make/precompiler.ex
@@ -74,8 +74,9 @@ defmodule ElixirMake.Precompiler do
   @doc """
   Optional recover actions when the current target is unavailable.
 
-  There are two reasons that the current target might be unavailable when
-  the library only has precompiled binaries for some platforms, and it either
+  There are two reasons that the current target might be unavailable:
+  when the library only has precompiled binaries for some platforms,
+  and it either
 
   - needs to be compiled on other platforms.
 

--- a/lib/elixir_make/precompiler.ex
+++ b/lib/elixir_make/precompiler.ex
@@ -71,7 +71,25 @@ defmodule ElixirMake.Precompiler do
   """
   @callback post_precompile() :: :ok
 
-  @optional_callbacks post_precompile: 0
+  @doc """
+  Optional recover actions when the current target is unavailable.
+
+  There are two reasons that the current target might be unavailable when
+  the library only has precompiled binaries for some platforms, and it either
+
+  - needs to be compiled on other platforms.
+
+    The callback should return `:compile` for this case.
+
+  - is intended to function as `noop` on other platforms.
+
+    The callback should return `:ignore` for this case.
+
+  Defaults to `:compile` if this callback is not implemented.
+  """
+  @callback unavailable_target(String.t()) :: :compile | :ignore
+
+  @optional_callbacks post_precompile: 0, unavailable_target: 1
 
   @doc """
   Invoke the regular Mix toolchain compilation.

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -48,6 +48,22 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
         Keyword.get(options, :only_local) ->
           case Artefact.current_target_url(config, precompiler) do
             {:ok, target, url} -> [{target, url}]
+            {:error, {:unavailable_target, current_target, available_targets, error}} ->
+              recover = config[:make_precompiler_unavailable_target] || :compile
+
+              recover =
+                if is_function(recover, 2) do
+                  recover.(current_target, available_targets)
+                else
+                  recover
+                end
+
+              case recover do
+                :compile ->
+                  Mix.raise(error)
+                :ignore ->
+                  []
+              end
             {:error, error} -> Mix.raise(error)
           end
 

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -50,14 +50,12 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
             {:ok, target, url} ->
               [{target, url}]
 
-            {:error, {:unavailable_target, current_target, available_targets, error}} ->
-              recover = config[:make_precompiler_unavailable_target] || :compile
-
+            {:error, {:unavailable_target, current_target, error}} ->
               recover =
-                if is_function(recover, 2) do
-                  recover.(current_target, available_targets)
+                if function_exported?(precompiler, :unavailable_target, 1) do
+                  precompiler.unavailable_target(current_target)
                 else
-                  recover
+                  :compile
                 end
 
               case recover do

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -47,7 +47,9 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
 
         Keyword.get(options, :only_local) ->
           case Artefact.current_target_url(config, precompiler) do
-            {:ok, target, url} -> [{target, url}]
+            {:ok, target, url} ->
+              [{target, url}]
+
             {:error, {:unavailable_target, current_target, available_targets, error}} ->
               recover = config[:make_precompiler_unavailable_target] || :compile
 
@@ -61,10 +63,13 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
               case recover do
                 :compile ->
                   Mix.raise(error)
+
                 :ignore ->
                   []
               end
-            {:error, error} -> Mix.raise(error)
+
+            {:error, error} ->
+              Mix.raise(error)
           end
 
         true ->


### PR DESCRIPTION
Adding support for specifying how to recover from unavailable targets using the `make_precompiler_unavailable_target` config key (probably needs a shorter name for this). Allowed values are `:compile` and `:ignore`. Defaults to `:compile`.

It is also possible to pass in a 2-arity function to `make_precompiler_unavailable_target`: the first argument is the triplet of the unavailable target, and the second argument is a list that contains all available targets provided by the precompiler.

One use case is the `dll_loader_helper`, which only needs to be compiled on windows and ignores the compilation process for all other targets. 

For instance ([cocoa-xu/dll_loader_helper #8](https://github.com/cocoa-xu/dll_loader_helper/pull/8)):

```elixir
  def project do
    [
      ...,
      make_precompiler_unavailable_target: &unavailable_target/2,
      cc_precompiler: [
        only_listed_compilers: true,
        compilers: %{
          {:win32, :nt} => %{
            "x86_64-windows-msvc" => {"cl", "cl"}
          }
        }
      ]
    ]
  end

  defp unavailable_target("x86_64-windows-msvc", _), do: :compile
  defp unavailable_target(_, _), do: :ignore
```
