### PR TITLE
added optional callback post_target_archive/1 for precompiler

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -708,7 +708,7 @@ defmodule CCPrecompiler do
   end
 
   @impl ElixirMake.Precompiler
-  def post_target_archive(target) do
+  def post_precompile_target(target) do
     # It's possible to do some cleanup work
     # in this optionall callback
     # it will be called when `target` is properly archived

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -708,6 +708,16 @@ defmodule CCPrecompiler do
   end
 
   @impl ElixirMake.Precompiler
+  def post_target_archive(target) do
+    # It's possible to do some cleanup work
+    # in this optionall callback
+    # it will be called when `target` is properly archived
+    # so you may safely delete all target-specific files,
+    # like call `make clean`
+    Logger.debug("Post target archive")
+  end
+
+  @impl ElixirMake.Precompiler
   def post_precompile() do
     # It's possible to do some post precompilation work
     # in this optionall callback

--- a/lib/elixir_make/precompiler.ex
+++ b/lib/elixir_make/precompiler.ex
@@ -69,7 +69,7 @@ defmodule ElixirMake.Precompiler do
   It will be called when a target is precompiled and archived successfully.
   For example, actions can be deleting all target-specific files.
   """
-  @callback post_target_archive(target) :: :ok
+  @callback post_precompile_target(target) :: :ok
 
   @doc """
   Optional post actions to run after all precompilation tasks are done.
@@ -99,7 +99,7 @@ defmodule ElixirMake.Precompiler do
   """
   @callback unavailable_target(String.t()) :: :compile | :ignore
 
-  @optional_callbacks post_precompile: 0, unavailable_target: 1, post_target_archive: 1
+  @optional_callbacks post_precompile: 0, unavailable_target: 1, post_precompile_target: 1
 
   @doc """
   Invoke the regular Mix toolchain compilation.

--- a/lib/elixir_make/precompiler.ex
+++ b/lib/elixir_make/precompiler.ex
@@ -64,6 +64,14 @@ defmodule ElixirMake.Precompiler do
   @callback precompile(OptionParser.argv(), target) :: :ok | {:error, String.t()}
 
   @doc """
+  Optional post actions to run after each precompilation target is archived.
+
+  It will be called when a target is precompiled and archived successfully.
+  For example, actions can be deleting all target-specific files.
+  """
+  @callback post_target_archive(target) :: :ok
+
+  @doc """
   Optional post actions to run after all precompilation tasks are done.
 
   It will only be called at the end of the `mix elixir_make.precompile` command.
@@ -91,7 +99,7 @@ defmodule ElixirMake.Precompiler do
   """
   @callback unavailable_target(String.t()) :: :compile | :ignore
 
-  @optional_callbacks post_precompile: 0, unavailable_target: 1
+  @optional_callbacks post_precompile: 0, unavailable_target: 1, post_target_archive: 1
 
   @doc """
   Invoke the regular Mix toolchain compilation.

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -33,7 +33,13 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
       precompiled_artefacts =
         Enum.map(targets, fn target ->
           case precompiler.precompile(args, target) do
-            :ok -> create_precompiled_archive(config, target, paths)
+            :ok ->
+              create_precompiled_archive(config, target, paths)
+              if function_exported?(precompiler, :post_target_archive, 1) do
+                precompiler.post_target_archive(target)
+              else
+                :ok
+              end
             {:error, msg} -> Mix.raise(msg)
           end
         end)

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -35,12 +35,15 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
           case precompiler.precompile(args, target) do
             :ok ->
               create_precompiled_archive(config, target, paths)
-              if function_exported?(precompiler, :post_target_archive, 1) do
-                precompiler.post_target_archive(target)
+
+              if function_exported?(precompiler, :post_precompile_target, 1) do
+                precompiler.post_precompile_target(target)
               else
                 :ok
               end
-            {:error, msg} -> Mix.raise(msg)
+
+            {:error, msg} ->
+              Mix.raise(msg)
           end
         end)
 

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -34,13 +34,13 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
         Enum.map(targets, fn target ->
           case precompiler.precompile(args, target) do
             :ok ->
-              create_precompiled_archive(config, target, paths)
+              precompiled_artefacts = create_precompiled_archive(config, target, paths)
 
               if function_exported?(precompiler, :post_precompile_target, 1) do
                 precompiler.post_precompile_target(target)
-              else
-                :ok
               end
+
+              precompiled_artefacts
 
             {:error, msg} ->
               Mix.raise(msg)


### PR DESCRIPTION
This PR adds an optional callback `post_target_archive/1` for the precompiler.

Linked to issue: #67 