### PR TITLE
Fix ubuntu-version and change setup-elixir to setup-beam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - fix-ci-action-dependency
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: test
     strategy:
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}


### PR DESCRIPTION
The OTP 20.3 build is not present in the Hex build list for Ubuntu 22.04, so pinning the Ubuntu version to the previous one fix the build error. Related Issue: https://github.com/elixir-lang/elixir_make/issues/69#issue-1575436270