### PR TITLE
[precompilation] add support for multiple NIF versions

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -43,7 +43,7 @@ def project do
     make_precompiler_filename: "nif",
     make_precompiler_priv_paths: ["nif.*"],
     make_precompiler_nif_versions: [
-      verisions: ["2.14", "2.15", "2.16"],
+      versions: ["2.14", "2.15", "2.16"],
       availability: &target_available_for_nif_version?/2
     ]
     # ...
@@ -113,12 +113,12 @@ The third optional config key is `make_precompiler_nif_versions`. The default va
 
 If you'd like to aim for an older NIF version, say `2.15` for Erlang/OTP 23 and 24, then you need to setup CI correspondingly and set the value of this key to `[versions: ["2.15", "2.16"]]`. This optional key will only be checked when downloading precompiled artefacts.
 
-For some platforms maybe we only have precompiled artefacts after a certain NIF version, say for x86_64 Windows we have precompiled artefacts available when NIF verision >= `2.16` while other platforms have precompiled artefacts available from NIF version >= `2.15`.
+For some platforms maybe we only have precompiled artefacts after a certain NIF version, say for x86_64 Windows we have precompiled artefacts available when NIF version >= `2.16` while other platforms have precompiled artefacts available from NIF version >= `2.15`.
 
 In such case we can inform `:elixir_make` that Windows targets don't have precompiled artefacts available except for NIF version `2.16` by passing a function to the `availability` sub-key.
 
 ```elixir
-def target_available_for_nif_version?(target, nif_version) do
+defp target_available_for_nif_version?(target, nif_version) do
   if String.contains?(target, "windows") do
     nif_version == "2.16"
   else

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -151,20 +151,29 @@ defmodule ElixirMake.Artefact do
       config[:make_precompiler_url] ||
         Mix.raise("`make_precompiler_url` is not specified in `project`")
 
-    nif_versions = config[:make_precompiler_nif_versions] || [versions: ["#{:erlang.system_info(:nif_version)}"]]
+    nif_versions =
+      config[:make_precompiler_nif_versions] ||
+        [versions: ["#{:erlang.system_info(:nif_version)}"]]
+
     Enum.reduce(targets, [], fn target, archives ->
       archive_filenames =
         Enum.reduce(nif_versions[:versions], [], fn nif_version, acc ->
           availability = nif_versions[:availability]
-          available? = if is_function(availability, 2) do
-            availability.(target, nif_version)
-          else
-            true
-          end
+
+          available? =
+            if is_function(availability, 2) do
+              availability.(target, nif_version)
+            else
+              true
+            end
 
           if available? do
             archive_filename = archive_filename(config, target, nif_version)
-            [{target, String.replace(url_template, "@{artefact_filename}", archive_filename)} | acc]
+
+            [
+              {target, String.replace(url_template, "@{artefact_filename}", archive_filename)}
+              | acc
+            ]
           else
             acc
           end

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -207,6 +207,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   defp download_or_reuse_nif(config, precompiler, app_priv) do
     # should we allow this value to be overwritten by an env var?
     nif_version = :erlang.system_info(:nif_version)
+
     case Artefact.current_target_url(config, precompiler, nif_version) do
       {:ok, target, url} ->
         archived_fullpath = Artefact.archive_path(config, target, nif_version)

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -205,9 +205,11 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   end
 
   defp download_or_reuse_nif(config, precompiler, app_priv) do
-    case Artefact.current_target_url(config, precompiler) do
+    # should we allow this value to be overwritten by an env var?
+    nif_version = :erlang.system_info(:nif_version)
+    case Artefact.current_target_url(config, precompiler, nif_version) do
       {:ok, target, url} ->
-        archived_fullpath = Artefact.archive_path(config, target)
+        archived_fullpath = Artefact.archive_path(config, target, nif_version)
 
         unless File.exists?(archived_fullpath) do
           Mix.shell().info("Downloading precompiled NIF to #{archived_fullpath}")

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
           Artefact.available_target_urls(config, precompiler)
 
         Keyword.get(options, :only_local) ->
-          case Artefact.current_target_url(config, precompiler) do
+          case Artefact.current_target_url(config, precompiler, :erlang.system_info(:nif_version)) do
             {:ok, target, url} ->
               [{target, url}]
 

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
   end
 
   defp create_precompiled_archive(config, target, paths) do
-    archive_path = Artefact.archive_path(config, target)
+    archive_path = Artefact.archive_path(config, target, :erlang.system_info(:nif_version))
 
     Mix.shell().info("Creating precompiled archive: #{archive_path}")
     Mix.shell().info("Paths to archive from priv directory: #{inspect(paths)}")


### PR DESCRIPTION
Previously the NIF version is hard-coded as `:erlang.system_info(:nif_version)` in `ElixirMake.Artefact.archive_filename/2`, which would only generate archive filenames for the current NIF version (whichever value the current Erlang/OTP happens to be).

This PR adds an optional config key `make_precompiler_nif_versions` that allows users to set all available NIF versions for their precompiled artefacts in the `versions` sub-key.

Furthermore, an `availability` sub-key is introduced to tell if the current combination of `target` and `nif_version` is available. Adding this sub-key solves an issue that for some platforms, maybe we only have precompiled artefacts after a certain NIF version, say for x86_64 Windows we have precompiled artefacts available when NIF version >= `2.16` while other platforms have precompiled artefacts available from NIF version >= `2.15`.

In such case, we can inform `:elixir_make` that Windows targets don't have precompiled artefacts available except for NIF version `2.16` by passing a function to the `availability` sub-key.

```elixir
def project do
  [
    # ...
    make_precompiler_nif_versions: [
      versions: ["2.15", "2.16"],
      availability: &target_available_for_nif_version?/2
    ]
    # ...
  ]
end

defp target_available_for_nif_version?(target, nif_version) do
  if String.contains?(target, "windows") do
    nif_version == "2.16"
  else
    true
  end
end
```

After applying these changes, we can download all available precompiled artefacts. 

Testing project [cocoa-xu/exqlite](https://github.com/cocoa-xu/exqlite)

```bash
$ MIX_ENV=prod mix elixir_make.checksum --all --print
==> elixir_make
Compiling 6 files (.ex)
Generated elixir_make app
==> cc_precompiler
Compiling 3 files (.ex)
Generated cc_precompiler app
==> exqlite
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-riscv64-linux-gnu-0.13.2.tar.gz with checksum a9920906c5affa7d7a745d1f6d192753c1c9d05869bb928ae12e16f830a2dbd2 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-powerpc64le-linux-gnu-0.13.2.tar.gz with checksum d158a6b1d0f4eafba5b1e1215324b7f9c9b1e134ff45e312eb7c33a6bfbf5efc (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-x86_64-linux-gnu-0.13.2.tar.gz with checksum 7d403576212dfcdc33712f140e93774f1d1a1c97c0174d934c019e7027e619c8 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-i686-linux-gnu-0.13.2.tar.gz with checksum 2b1b8bbc4719ea0c99556f5d941a9ded1a721c5f709da0981fc8da037b0a5ec2 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-s390x-linux-gnu-0.13.2.tar.gz with checksum 3e80084e54357b09253f570b23ded5614749ba3b5970e95b871c17380a21deca (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-x86_64-windows-msvc-0.13.2.tar.gz with checksum ee5c142621d6fd17b5cc8f26ec25d79429c7047dc3edae21000cb37adae1770e (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-s390x-linux-gnu-0.13.2.tar.gz with checksum 56ad9311f241b0ea95c7bc11d638ac220408e80fe0c671449ac061a0d7ae0eda (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-armv7l-linux-gnueabihf-0.13.2.tar.gz with checksum c3fdb78bf1c8cf4e2b7662054d60eca0627ae53df8c06c74ee8067f0f43f0d5d (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-powerpc64le-linux-gnu-0.13.2.tar.gz with checksum 69b773081f40b7e9b620bde92c97610067b03fb4e74d00bd6e7f22d610d82abe (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-riscv64-linux-gnu-0.13.2.tar.gz with checksum 1a8539f8a393c0e5bb6ba061cc62b8d49e311b2f00b426bd7770b7c59d20632e (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-aarch64-linux-gnu-0.13.2.tar.gz with checksum a87db9798d1dc0283ebc320025d954c4e362aaf6adcfcf4ddc7951bd59b177a8 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-x86_64-apple-darwin-0.13.2.tar.gz with checksum f6a8ffd2be478c592d3fc3a293689d9106008eac894d57a97c837185882f5dd3 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.16-aarch64-apple-darwin-0.13.2.tar.gz with checksum b62749f0522f17919e0c9a63db2b598842cba3414cfd4005e605e580570fb35e (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-x86_64-apple-darwin-0.13.2.tar.gz with checksum 9505e6d7eb38a4363fda2e70386f5add3ca20f52b2cf73d971cb027e0d4fec82 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-x86_64-linux-gnu-0.13.2.tar.gz with checksum aef3206a24c84e91a3786822e66c7c0ebeed3b4fa99f55a078d21c7b905f6db8 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-i686-linux-gnu-0.13.2.tar.gz with checksum f39d990b6bf2f5e6b30956bfb8ac0bafbf099fa62b34f0cb6b4b8e9e2d9f8c6a (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-armv7l-linux-gnueabihf-0.13.2.tar.gz with checksum 2317e589c3d323b91c60f02eb5353dc77e9b5066e345c4d763141539e00a6bbe (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-aarch64-linux-gnu-0.13.2.tar.gz with checksum 51e4f72cecc28e08fee257b0c7637d99d8faea7717a2fcbeb9021da5d701cd90 (sha256)
NIF cached at /Users/cocoa/Library/Caches/exqlite-nif-2.15-aarch64-apple-darwin-0.13.2.tar.gz with checksum cf625e7a850426df2514ee60d65690e3484c943faf8c51e983df1416e930c0c6 (sha256)
cf625e7a850426df2514ee60d65690e3484c943faf8c51e983df1416e930c0c6  exqlite-nif-2.15-aarch64-apple-darwin-0.13.2.tar.gz
51e4f72cecc28e08fee257b0c7637d99d8faea7717a2fcbeb9021da5d701cd90  exqlite-nif-2.15-aarch64-linux-gnu-0.13.2.tar.gz
2317e589c3d323b91c60f02eb5353dc77e9b5066e345c4d763141539e00a6bbe  exqlite-nif-2.15-armv7l-linux-gnueabihf-0.13.2.tar.gz
f39d990b6bf2f5e6b30956bfb8ac0bafbf099fa62b34f0cb6b4b8e9e2d9f8c6a  exqlite-nif-2.15-i686-linux-gnu-0.13.2.tar.gz
69b773081f40b7e9b620bde92c97610067b03fb4e74d00bd6e7f22d610d82abe  exqlite-nif-2.15-powerpc64le-linux-gnu-0.13.2.tar.gz
1a8539f8a393c0e5bb6ba061cc62b8d49e311b2f00b426bd7770b7c59d20632e  exqlite-nif-2.15-riscv64-linux-gnu-0.13.2.tar.gz
56ad9311f241b0ea95c7bc11d638ac220408e80fe0c671449ac061a0d7ae0eda  exqlite-nif-2.15-s390x-linux-gnu-0.13.2.tar.gz
9505e6d7eb38a4363fda2e70386f5add3ca20f52b2cf73d971cb027e0d4fec82  exqlite-nif-2.15-x86_64-apple-darwin-0.13.2.tar.gz
aef3206a24c84e91a3786822e66c7c0ebeed3b4fa99f55a078d21c7b905f6db8  exqlite-nif-2.15-x86_64-linux-gnu-0.13.2.tar.gz
b62749f0522f17919e0c9a63db2b598842cba3414cfd4005e605e580570fb35e  exqlite-nif-2.16-aarch64-apple-darwin-0.13.2.tar.gz
a87db9798d1dc0283ebc320025d954c4e362aaf6adcfcf4ddc7951bd59b177a8  exqlite-nif-2.16-aarch64-linux-gnu-0.13.2.tar.gz
c3fdb78bf1c8cf4e2b7662054d60eca0627ae53df8c06c74ee8067f0f43f0d5d  exqlite-nif-2.16-armv7l-linux-gnueabihf-0.13.2.tar.gz
2b1b8bbc4719ea0c99556f5d941a9ded1a721c5f709da0981fc8da037b0a5ec2  exqlite-nif-2.16-i686-linux-gnu-0.13.2.tar.gz
d158a6b1d0f4eafba5b1e1215324b7f9c9b1e134ff45e312eb7c33a6bfbf5efc  exqlite-nif-2.16-powerpc64le-linux-gnu-0.13.2.tar.gz
a9920906c5affa7d7a745d1f6d192753c1c9d05869bb928ae12e16f830a2dbd2  exqlite-nif-2.16-riscv64-linux-gnu-0.13.2.tar.gz
3e80084e54357b09253f570b23ded5614749ba3b5970e95b871c17380a21deca  exqlite-nif-2.16-s390x-linux-gnu-0.13.2.tar.gz
f6a8ffd2be478c592d3fc3a293689d9106008eac894d57a97c837185882f5dd3  exqlite-nif-2.16-x86_64-apple-darwin-0.13.2.tar.gz
7d403576212dfcdc33712f140e93774f1d1a1c97c0174d934c019e7027e619c8  exqlite-nif-2.16-x86_64-linux-gnu-0.13.2.tar.gz
ee5c142621d6fd17b5cc8f26ec25d79429c7047dc3edae21000cb37adae1770e  exqlite-nif-2.16-x86_64-windows-msvc-0.13.2.tar.gz
```