### PR TITLE
[fix] finding the correct URL of the current target

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -193,8 +193,6 @@ defmodule ElixirMake.Artefact do
         available_urls = available_target_urls(config, precompiler)
         target_at_nif_version = {current_target, nif_version}
 
-        IO.inspect(available_urls, label: "available_urls")
-
         case List.keyfind(available_urls, target_at_nif_version, 0) do
           {^target_at_nif_version, download_url} ->
             {:ok, current_target, download_url}

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -142,7 +142,7 @@ defmodule ElixirMake.Artefact do
   ## Archive/NIF urls
 
   @doc """
-  Returns all available target-url pairs available.
+  Returns all available {{target, nif_version}, url} pairs available.
   """
   def available_target_urls(config, precompiler) do
     targets = precompiler.all_supported_targets(:fetch)
@@ -171,7 +171,8 @@ defmodule ElixirMake.Artefact do
             archive_filename = archive_filename(config, target, nif_version)
 
             [
-              {target, String.replace(url_template, "@{artefact_filename}", archive_filename)}
+              {{target, nif_version},
+               String.replace(url_template, "@{artefact_filename}", archive_filename)}
               | acc
             ]
           else
@@ -187,12 +188,15 @@ defmodule ElixirMake.Artefact do
   Returns the url for the current target.
   """
   def current_target_url(config, precompiler, nif_version) do
-    case precompiler.current_target(nif_version) do
+    case precompiler.current_target() do
       {:ok, current_target} ->
         available_urls = available_target_urls(config, precompiler)
+        target_at_nif_version = {current_target, nif_version}
 
-        case List.keyfind(available_urls, current_target, 0) do
-          {^current_target, download_url} ->
+        IO.inspect(available_urls, label: "available_urls")
+
+        case List.keyfind(available_urls, target_at_nif_version, 0) do
+          {^target_at_nif_version, download_url} ->
             {:ok, current_target, download_url}
 
           nil ->

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -206,7 +206,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
 
   defp download_or_reuse_nif(config, precompiler, app_priv) do
     # should we allow this value to be overwritten by an env var?
-    nif_version = :erlang.system_info(:nif_version)
+    nif_version = "#{:erlang.system_info(:nif_version)}"
 
     case Artefact.current_target_url(config, precompiler, nif_version) do
       {:ok, target, url} ->

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -205,7 +205,6 @@ defmodule Mix.Tasks.Compile.ElixirMake do
   end
 
   defp download_or_reuse_nif(config, precompiler, app_priv) do
-    # should we allow this value to be overwritten by an env var?
     nif_version = "#{:erlang.system_info(:nif_version)}"
 
     case Artefact.current_target_url(config, precompiler, nif_version) do

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
         Keyword.get(options, :only_local) ->
           case Artefact.current_target_url(config, precompiler, :erlang.system_info(:nif_version)) do
             {:ok, target, url} ->
-              [{target, url}]
+              [{{target, "#{:erlang.system_info(:nif_version)}"}, url}]
 
             {:error, {:unavailable_target, current_target, error}} ->
               recover =
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
     tasks =
       Task.async_stream(
         urls,
-        fn {_target, url} -> {url, Artefact.download(url)} end,
+        fn {{_target, _nif_version}, url} -> {url, Artefact.download(url)} end,
         timeout: :infinity,
         ordered: false
       )


### PR DESCRIPTION
When generating URLs in `ElixirMake.Artefact.available_target_urls/2`, we should return `{{target, nif_version}, url}` pairs instead of `{target, url}`. 

Then we can find the correct URL of the current target with `{current_target, nif_version}` as the key.

Sorry for the second PR. Once this is merged, I'll test it a little bit, and if everything works, we can ship a new version!