### PR TITLE
check application-specific `make_force_build` values in `config.exs`

### DIFF
--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -129,7 +129,17 @@ defmodule Mix.Tasks.Compile.ElixirMake do
     config = Mix.Project.config()
     app = config[:app]
     version = config[:version]
-    force_build = pre_release?(version) or Keyword.get(config, :make_force_build, false)
+    force_build = Application.fetch_env(app, :make_force_build)
+
+    force_build =
+      case force_build do
+        {:ok, value} when is_boolean(value) ->
+          value
+
+        _ ->
+          pre_release?(version) or Keyword.get(config, :make_force_build, false)
+      end
+
     {precompiler_type, precompiler} = config[:make_precompiler] || {nil, nil}
 
     cond do


### PR DESCRIPTION
This PR allows users to set application-specific `make_force_build` values in `config.exs` for the following reasons:

1. when the precompiled artefacts are linked with a higher version of glibc. In such case, the shared library will fail to load even if the target triplet matches.

   ```elixir
   iex> Mix.install([{:exqlite, "~> 0.13.4"}])
   iex> {:ok, conn} = Exqlite.Sqlite3.open(":memory:")
   ** (UndefinedFunctionError) function Exqlite.Sqlite3NIF.open/2 is undefined (module Exqlite.Sqlite3NIF is not available)
       (exqlite 0.13.4) Exqlite.Sqlite3NIF.open(':memory:', 6)
       iex:1: (file)
   iex>
   16:47:22.044 [warning] The on_load function for module Elixir.Exqlite.Sqlite3NIF returned:
   {:error,
    {:load_failed,
     'Failed to load NIF library: \'/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28\' not found (required by 
   /root/myapp/_build/dev/lib/exqlite/priv/sqlite3_nif.so)\''}}
   ```

2. When the user wants to compile a NIF library natively on the host (to get better optimization, etc).

With this patch applied, users can set `make_force_build` option for each app. For example, to opt out of using precompiled artefacts of `exqlite`, they can have the following settings in their `config/config.exs`:

```elixir
import Config

config :exqlite, make_force_build: true
```

Related issue: https://github.com/elixir-sqlite/exqlite/issues/238