### PR TITLE
Silent instead of displaying error message when a target is unavailable

### DIFF
--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -174,6 +174,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
               case reason do
                 :unavailable_target ->
                   nil
+
                 _ ->
                   Mix.shell().error("""
                   Error happened while installing #{app} from precompiled binary: #{error_msg}.

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -173,10 +173,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
             :compile ->
               case reason do
                 :unavailable_target ->
-                  Mix.shell().info("""
-                  Attempting to compile #{app} from source...\
-                  """)
-
+                  nil
                 _ ->
                   Mix.shell().error("""
                   Error happened while installing #{app} from precompiled binary: #{error_msg}.


### PR DESCRIPTION
This PR makes it silently fallback to `compile` or `ignore` when there is no precompiled binary for the current target (i.e., no corresponding entry existing in the `checksum.exs`) instead of an error message.

Related issue: https://github.com/elixir-sqlite/exqlite/issues/243