### PR TITLE
Allow libraries to reuse binaries compiled with older NIF versions

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -43,8 +43,7 @@ def project do
     make_precompiler_filename: "nif",
     make_precompiler_priv_paths: ["nif.*"],
     make_precompiler_nif_versions: [
-      versions: ["2.14", "2.15", "2.16"],
-      availability: &target_available_for_nif_version?/2
+      versions: ["2.14", "2.15", "2.16"]
     ]
     # ...
   ]

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -146,7 +146,7 @@ defmodule ElixirMake.Artefact do
     {String.to_integer(major), String.to_integer(minor)}
   end
 
-  defp find_nif_version(current_nif_version, versions) do
+  defp find_nif_version(_current_target, current_nif_version, versions) do
     if current_nif_version in versions do
       current_nif_version
     else
@@ -161,7 +161,7 @@ defmodule ElixirMake.Artefact do
 
       case Enum.sort(candidates) do
         [{_, version} | _] -> version
-        _ -> :no_candidates
+        _ -> current_nif_version
       end
     end
   end
@@ -224,7 +224,7 @@ defmodule ElixirMake.Artefact do
             [versions: []]
 
         versions = nif_versions[:versions]
-        fallback_version = nif_versions[:fallback_version] || &find_nif_version/3
+        fallback_version = nif_versions[:fallback_version] || (&find_nif_version/3)
         nif_version_to_use = fallback_version.(current_target, current_nif_version, versions)
 
         available_urls = available_target_urls(config, precompiler)

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -183,18 +183,10 @@ defmodule ElixirMake.Artefact do
         [versions: [current_nif_version]]
 
     versions = nif_versions[:versions]
-    versions_for_target = nif_versions[:versions_for_target]
 
     Enum.reduce(targets, [], fn target, archives ->
-      target_versions =
-        if is_function(versions_for_target, 1) do
-          versions_for_target.(target)
-        else
-          versions
-        end
-
       archive_filenames =
-        Enum.reduce(target_versions, [], fn nif_version_for_target, acc ->
+        Enum.reduce(versions, [], fn nif_version_for_target, acc ->
           archive_filename = archive_filename(config, target, nif_version_for_target)
 
           [
@@ -220,20 +212,12 @@ defmodule ElixirMake.Artefact do
 
         versions = nif_versions[:versions]
         fallback_version = nif_versions[:fallback_version]
-        versions_for_target = nif_versions[:versions_for_target]
-
-        target_versions =
-          if is_function(versions_for_target, 1) do
-            versions_for_target.(current_target)
-          else
-            versions
-          end
 
         nif_version_to_use =
-          case find_nif_version(current_nif_version, target_versions) do
+          case find_nif_version(current_nif_version, versions) do
             :no_candidates ->
               if is_function(fallback_version, 3) do
-                fallback_version.(current_target, current_nif_version, target_versions)
+                fallback_version.(current_target, current_nif_version, versions)
               else
                 current_nif_version
               end

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -151,6 +151,7 @@ defmodule ElixirMake.Artefact do
       current_nif_version
     else
       {major, minor} = nif_version_to_tuple(current_nif_version)
+
       # Get all matching major versions, earlier than the current version
       # and their distance. We want the closest (smallest distance).
       candidates =

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -243,7 +243,7 @@ defmodule ElixirMake.Artefact do
       {:ok, current_target} ->
         nif_versions =
           config[:make_precompiler_nif_versions] ||
-            [versions: [current_nif_version]]
+            [versions: []]
 
         versions = nif_versions[:versions]
         fallback_version = nif_versions[:fallback_version]

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -213,7 +213,7 @@ defmodule ElixirMake.Artefact do
 
           [
             {{target, nif_version_for_target},
-              String.replace(url_template, "@{artefact_filename}", archive_filename)}
+             String.replace(url_template, "@{artefact_filename}", archive_filename)}
             | acc
           ]
         end)

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -256,19 +256,25 @@ defmodule ElixirMake.Artefact do
               version
           end
 
-        available_urls = available_target_urls(config, precompiler)
-        target_at_nif_version = {current_target, nif_version_to_use}
+        case nif_version_to_use do
+          :compile ->
+            {:error, :compile_from_source}
 
-        case List.keyfind(available_urls, target_at_nif_version, 0) do
-          {^target_at_nif_version, download_url} ->
-            {:ok, current_target, download_url}
+          _ ->
+            available_urls = available_target_urls(config, precompiler)
+            target_at_nif_version = {current_target, nif_version_to_use}
 
-          nil ->
-            available_targets = Enum.map(available_urls, fn {target, _url} -> target end)
+            case List.keyfind(available_urls, target_at_nif_version, 0) do
+              {^target_at_nif_version, download_url} ->
+                {:ok, current_target, download_url}
 
-            {:error,
-             {:unavailable_target, current_target,
-              "cannot find download url for current target `#{inspect(current_target)}`. Available targets are: #{inspect(available_targets)}"}}
+              nil ->
+                available_targets = Enum.map(available_urls, fn {target, _url} -> target end)
+
+                {:error,
+                 {:unavailable_target, current_target,
+                  "cannot find download url for current target `#{inspect(current_target)}`. Available targets are: #{inspect(available_targets)}"}}
+            end
         end
 
       {:error, msg} ->

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -224,20 +224,8 @@ defmodule ElixirMake.Artefact do
             [versions: []]
 
         versions = nif_versions[:versions]
-        fallback_version = nif_versions[:fallback_version]
-
-        nif_version_to_use =
-          case find_nif_version(current_nif_version, versions) do
-            :no_candidates ->
-              if is_function(fallback_version, 3) do
-                fallback_version.(current_target, current_nif_version, versions)
-              else
-                current_nif_version
-              end
-
-            version when is_binary(version) ->
-              version
-          end
+        fallback_version = nif_versions[:fallback_version] || &find_nif_version/3
+        nif_version_to_use = fallback_version.(current_target, current_nif_version, versions)
 
         case nif_version_to_use do
           :compile ->

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -209,26 +209,13 @@ defmodule ElixirMake.Artefact do
 
       archive_filenames =
         Enum.reduce(target_versions, [], fn nif_version_for_target, acc ->
-          availability = nif_versions[:availability]
+          archive_filename = archive_filename(config, target, nif_version_for_target)
 
-          available? =
-            if is_function(availability, 2) do
-              availability.(target, nif_version_for_target)
-            else
-              true
-            end
-
-          if available? do
-            archive_filename = archive_filename(config, target, nif_version_for_target)
-
-            [
-              {{target, nif_version_for_target},
-               String.replace(url_template, "@{artefact_filename}", archive_filename)}
-              | acc
-            ]
-          else
-            acc
-          end
+          [
+            {{target, nif_version_for_target},
+              String.replace(url_template, "@{artefact_filename}", archive_filename)}
+            | acc
+          ]
         end)
 
       archive_filenames ++ archives

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -66,26 +66,12 @@ defmodule ElixirMake.Artefact do
   end
 
   defp archive_filename(config, target, nif_version) do
-    precompiler_archive_filename = config[:make_precompiler_archive_filename] || :default
-
     case config[:make_precompiler] do
       {:nif, _} ->
-        case precompiler_archive_filename do
-          func when is_function(func, 1) ->
-            func.(target: target)
-
-          _ ->
-            "#{config[:app]}-nif-#{nif_version}-#{target}-#{config[:version]}.tar.gz"
-        end
+        "#{config[:app]}-nif-#{nif_version}-#{target}-#{config[:version]}.tar.gz"
 
       {type, _} ->
-        case precompiler_archive_filename do
-          func when is_function(func, 1) ->
-            func.(target: target)
-
-          _ ->
-            "#{config[:app]}-#{type}-#{target}-#{config[:version]}.tar.gz"
-        end
+        "#{config[:app]}-#{type}-#{target}-#{config[:version]}.tar.gz"
     end
   end
 

--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -66,12 +66,26 @@ defmodule ElixirMake.Artefact do
   end
 
   defp archive_filename(config, target, nif_version) do
+    precompiler_archive_filename = config[:make_precompiler_archive_filename] || :default
+
     case config[:make_precompiler] do
       {:nif, _} ->
-        "#{config[:app]}-nif-#{nif_version}-#{target}-#{config[:version]}.tar.gz"
+        case precompiler_archive_filename do
+          func when is_function(func, 1) ->
+            func.(target: target)
+
+          _ ->
+            "#{config[:app]}-nif-#{nif_version}-#{target}-#{config[:version]}.tar.gz"
+        end
 
       {type, _} ->
-        "#{config[:app]}-#{type}-#{target}-#{config[:version]}.tar.gz"
+        case precompiler_archive_filename do
+          func when is_function(func, 1) ->
+            func.(target: target)
+
+          _ ->
+            "#{config[:app]}-#{type}-#{target}-#{config[:version]}.tar.gz"
+        end
     end
   end
 
@@ -151,37 +165,87 @@ defmodule ElixirMake.Artefact do
       config[:make_precompiler_url] ||
         Mix.raise("`make_precompiler_url` is not specified in `project`")
 
+    current_nif_version = "#{:erlang.system_info(:nif_version)}"
+
     nif_versions =
       config[:make_precompiler_nif_versions] ||
-        [versions: ["#{:erlang.system_info(:nif_version)}"]]
+        [versions: [current_nif_version]]
 
-    Enum.reduce(targets, [], fn target, archives ->
-      archive_filenames =
-        Enum.reduce(nif_versions[:versions], [], fn nif_version, acc ->
-          availability = nif_versions[:availability]
+    use_minimum_version = nif_versions[:use_minimum_version] || false
 
-          available? =
-            if is_function(availability, 2) do
-              availability.(target, nif_version)
+    if use_minimum_version do
+      minimum_version =
+        nif_versions[:minimum_version] ||
+          raise ArgumentError, """
+          `minimum_version` is not set in mix.exs while `use_minimum_version` is set to `true`.
+          `minimum_version` should be a string, e.g., "2.14" or a function that accepts two arguments, `target` and `current_nif_version`.
+          """
+
+      versions_for_target = nif_versions[:versions_for_target]
+
+      if is_binary(minimum_version) or is_function(minimum_version, 2) do
+        Enum.reduce(targets, [], fn target, archives ->
+          target_versions =
+            if is_function(versions_for_target, 1) do
+              versions_for_target.(target)
             else
-              true
+              target_minimum_version =
+                case minimum_version do
+                  v when is_binary(v) ->
+                    v
+
+                  f when is_function(f, 2) ->
+                    f.(target, current_nif_version)
+                end
+
+              [target_minimum_version]
             end
 
-          if available? do
-            archive_filename = archive_filename(config, target, nif_version)
+          archive_filenames =
+            Enum.map(target_versions, fn nif_version_for_target ->
+              archive_filename = archive_filename(config, target, nif_version_for_target)
 
-            [
-              {{target, nif_version},
+              {{target, nif_version_for_target},
                String.replace(url_template, "@{artefact_filename}", archive_filename)}
-              | acc
-            ]
-          else
-            acc
-          end
-        end)
+            end)
 
-      archive_filenames ++ archives
-    end)
+          archive_filenames ++ archives
+        end)
+      else
+        raise ArgumentError, """
+        `minimum_version` should be a string, e.g., "2.14" or a function that accepts two arguments, `target` and `current_nif_version`.
+        got #{inspect(minimum_version)}
+        """
+      end
+    else
+      Enum.reduce(targets, [], fn target, archives ->
+        archive_filenames =
+          Enum.reduce(nif_versions[:versions], [], fn nif_version, acc ->
+            availability = nif_versions[:availability]
+
+            available? =
+              if is_function(availability, 2) do
+                availability.(target, nif_version)
+              else
+                true
+              end
+
+            if available? do
+              archive_filename = archive_filename(config, target, nif_version)
+
+              [
+                {{target, nif_version},
+                 String.replace(url_template, "@{artefact_filename}", archive_filename)}
+                | acc
+              ]
+            else
+              acc
+            end
+          end)
+
+        archive_filenames ++ archives
+      end)
+    end
   end
 
   @doc """
@@ -191,7 +255,35 @@ defmodule ElixirMake.Artefact do
     case precompiler.current_target() do
       {:ok, current_target} ->
         available_urls = available_target_urls(config, precompiler)
-        target_at_nif_version = {current_target, nif_version}
+        IO.puts("available_urls: #{inspect(available_urls)}")
+
+        nif_versions =
+          config[:make_precompiler_nif_versions] ||
+            [versions: ["#{:erlang.system_info(:nif_version)}"]]
+
+        use_minimum_version = nif_versions[:use_minimum_version] || false
+
+        target_at_nif_version =
+          if use_minimum_version do
+            minimum_version =
+              nif_versions[:minimum_version] ||
+                raise ArgumentError, """
+                `minimum_version` is not set in mix.exs while `use_minimum_version` is set to `true`
+                """
+
+            minimum_version =
+              case minimum_version do
+                v when is_binary(v) ->
+                  v
+
+                f when is_function(f, 2) ->
+                  f.(current_target, nif_version)
+              end
+
+            {current_target, minimum_version}
+          else
+            {current_target, nif_version}
+          end
 
         case List.keyfind(available_urls, target_at_nif_version, 0) do
           {^target_at_nif_version, download_url} ->

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -167,9 +167,6 @@ defmodule Mix.Tasks.Compile.ElixirMake do
                   :compile
                 end
 
-              :compile_from_source ->
-                :compile
-
               _ ->
                 Mix.shell().error("""
                 Error happened while installing #{app} from precompiled binary: #{inspect(message)}.

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -167,6 +167,9 @@ defmodule Mix.Tasks.Compile.ElixirMake do
                   :compile
                 end
 
+              :compile_from_source ->
+                :compile
+
               _ ->
                 Mix.shell().error("""
                 Error happened while installing #{app} from precompiled binary: #{inspect(message)}.

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -54,9 +54,11 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
           Artefact.available_target_urls(config, precompiler)
 
         Keyword.get(options, :only_local) ->
-          case Artefact.current_target_url(config, precompiler, :erlang.system_info(:nif_version)) do
+          current_nif_version = "#{:erlang.system_info(:nif_version)}"
+
+          case Artefact.current_target_url(config, precompiler, current_nif_version) do
             {:ok, target, url} ->
-              [{{target, "#{:erlang.system_info(:nif_version)}"}, url}]
+              [{{target, current_nif_version}, url}]
 
             {:error, {:unavailable_target, current_target, error}} ->
               recover =


### PR DESCRIPTION
Hi this PR added a feature that allows libraries to reuse binaries compiled with older NIF versions instead of compiling the same code over and over again for all NIF versions they can support.

The main motivation is to reduce CI build time and release size as older NIF libraries can be used with newer Erlang/OTP versions.

This feature is done by changing how users can config the `:make_precompiler_nif_versions` key. And now there are two ways configure `elixir_make` on how to compile and reuse precompiled binaries. 

##### Use minimum NIF version (recommended)
The first way is to use the minimum NIF version that is available to the current target. For example, if the NIF library
only uses functions and feature available in NIF version `2.14`, the following configuration should be set:

```elixir
make_precompiler_nif_versions: [
  use_minimum_version: true,
  minimum_version: "2.14"
]
```

In this way, we can reuse the same precompiled binary for newer Erlang/OTP versions instead of compiling the same code over and over again. And if the user is using the NIF library on an older Erlang/OTP version, `elixir_make` will try to compile the NIF library for the target.

Additionally, if the NIF library can optionally use functions and/or features that are only available in NIF version `2.17`, then the following configuration can be set to provide better support for newer Erlang/OTP versions while still providing support for older Erlang/OTP versions:

```elixir
make_precompiler_nif_versions: [
  use_minimum_version: true,
  minimum_version: fn _target, current_nif_version ->
    if current_nif_version >= "2.17" do
        "2.17"
    else
        "2.14"
    end
  end
]
```

The above example tells `elixir_make` that it can reuse binaries compiled with NIF version `2.17` if the current host supports it; otherwise, it will use binaries compiled with NIF version `2.14`.

Users can further change the above example to use different target name to control which feature set is available. For example, to use NIF version `2.17` for any `aarch64` targets and `2.14` for other targets:

```elixir
make_precompiler_nif_versions: [
  use_minimum_version: true,
  minimum_version: fn target, current_nif_version ->
    if current_nif_version >= "2.17" and String.contains?(target, "aarch64") do
        "2.17"
    else
        "2.14"
    end
  end
]
```

However, the `versions_for_target` sub-key must be set to inform `:elixir_make` that the precompiled artefacts may have different NIF versions for different targets. For example,

```elixir
make_precompiler_nif_versions: [
  use_minimum_version: true,
  minimum_version: fn target, current_nif_version ->
    if current_nif_version >= "2.17" and String.contains?(target, "aarch64") do
        "2.17"
    else
        "2.14"
    end
  end,
  versions_for_target: fn target ->
    if String.contains?(target, "aarch64") do
      ["2.17", "2.14"]
    else
      ["2.14"]
    end
  end
]
```

This information is used to determine all available precompiled artefacts and is used to fetch all of them and generate the checksum file.

```elixir
make_precompiler_nif_versions: [
  use_minimum_version: true,
  minimum_version: fn target, current_nif_version ->
    if current_nif_version >= "2.17" do
        "2.17"
    else
        "2.14"
    end
  end
]
```

##### Use exact NIF version
The second (and the old) way is to use the exact NIF version that is available to the current target. In this case, a list of supported NIF versions should be set in key `versions`. For example, 

```elixir
make_precompiler_nif_versions: [versions: ["2.14", "2.15", "2.16"]]
```

The above example tells `elixir_make` that precompiled artefacts are available for these NIF versions. If there's no precompiled artefacts available on the current host, `elixir_make` will try to compile the NIF library.

If you'd like to aim for an older NIF version, say `2.15` for Erlang/OTP 23 and 24, then you need to setup CI correspondingly and set the value of this key to `[versions: ["2.15", "2.16"]]`. This optional key will only be checked when downloading precompiled artefacts.

For some platforms maybe we only have precompiled artefacts after a certain NIF version, say for x86_64 Windows we have precompiled artefacts available when NIF version >= `2.16` while other platforms have precompiled artefacts available from NIF version >= `2.15`.

In such case we can inform `:elixir_make` that Windows targets don't have precompiled artefacts available except for NIF version `2.16` by passing a function to the `availability` sub-key.

```elixir
defp target_available_for_nif_version?(target, nif_version) do
  if String.contains?(target, "windows") do
    nif_version == "2.16"
  else
    true
  end
end
```

The default value for `make_precompiler_nif_versions` is 

```elixir
[versions: ["#{:erlang.system_info(:nif_version)}"]]
```