### PR TITLE
fix download_or_reuse_nif

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -251,7 +251,7 @@ defmodule ElixirMake.Artefact do
 
         case List.keyfind(available_urls, target_at_nif_version, 0) do
           {^target_at_nif_version, download_url} ->
-            {:ok, current_target, download_url}
+            {:ok, current_target, nif_version_to_use, download_url}
 
           nil ->
             available_targets = Enum.map(available_urls, fn {target, _url} -> target end)

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -213,8 +213,8 @@ defmodule Mix.Tasks.Compile.ElixirMake do
     nif_version = "#{:erlang.system_info(:nif_version)}"
 
     case Artefact.current_target_url(config, precompiler, nif_version) do
-      {:ok, target, url} ->
-        archived_fullpath = Artefact.archive_path(config, target, nif_version)
+      {:ok, target, nif_version_to_use, url} ->
+        archived_fullpath = Artefact.archive_path(config, target, nif_version_to_use)
 
         unless File.exists?(archived_fullpath) do
           Mix.shell().info("Downloading precompiled NIF to #{archived_fullpath}")


### PR DESCRIPTION
return `{:ok, target, nif_version_to_use, url}` to `download_or_reuse_nif`, and further pass it to `Artefact.archive_path/3` so that `elixir_make` can find the correct filename and checksum in `checksum.exs`.