### PR TITLE
generate individual checksum file for each target

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -24,12 +24,32 @@ defmodule ElixirMake.Artefact do
   end
 
   @doc """
+  Returns the checksum algorithm
+  """
+  def checksum_algo do
+    @checksum_algo
+  end
+
+  @doc """
   Computes the checksum and artefact for the given contents.
   """
   def checksum(basename, contents) do
-    hash = :crypto.hash(@checksum_algo, contents)
+    hash = :crypto.hash(checksum_algo(), contents)
     checksum = Base.encode16(hash, case: :lower)
-    %Artefact{basename: basename, checksum: checksum, checksum_algo: @checksum_algo}
+    %Artefact{basename: basename, checksum: checksum, checksum_algo: checksum_algo()}
+  end
+
+  @doc """
+  Writes checksum for the target to disk.
+  """
+  def write_checksum_for_target!(%Artefact{
+        basename: basename,
+        checksum: checksum,
+        checksum_algo: checksum_algo
+      }) do
+    cache_dir = Artefact.cache_dir()
+    file = Path.join(cache_dir, "#{basename}.#{Atom.to_string(checksum_algo)}")
+    File.write!(file, [checksum, "  ", basename, "\n"])
   end
 
   @doc """

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -144,7 +144,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
     cache_dir = Artefact.cache_dir()
 
     Enum.flat_map(tasks, fn
-      {:ok, :checksum, url, artefact} ->
+      {:ok, :checksum, _url, artefact} ->
         Mix.shell().info(
           "NIF checksum file with checksum #{artefact.checksum} (#{artefact.checksum_algo})"
         )

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
                [checksum, basename] <- String.split(body, " ", trim: true) do
             {:checksum, url,
              %Artefact{
-               basename: basename,
+               basename: String.trim(basename),
                checksum: checksum,
                checksum_algo: checksum_algo
              }}

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -103,38 +103,79 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
     tasks =
       Task.async_stream(
         urls,
-        fn {{_target, _nif_version}, url} -> {url, Artefact.download(url)} end,
+        fn {{_target, _nif_version}, url} ->
+          checksum_algo = Artefact.checksum_algo()
+          checksum_file_url = "#{url}.#{Atom.to_string(checksum_algo)}"
+          artifact_checksum = Artefact.download(checksum_file_url)
+
+          from_checksum_file =
+            case artifact_checksum do
+              {:ok, body} ->
+                case String.split(body, " ", trim: true) do
+                  [checksum, basename] ->
+                    {:ok,
+                     {:checksum, url,
+                      %Artefact{
+                        basename: basename,
+                        checksum: checksum,
+                        checksum_algo: checksum_algo
+                      }}}
+
+                  _ ->
+                    :download_and_compute
+                end
+
+              _ ->
+                :download_and_compute
+            end
+
+          case from_checksum_file do
+            {:ok, packed} ->
+              packed
+
+            _ ->
+              {:download, url, Artefact.download(url)}
+          end
+        end,
         timeout: :infinity,
         ordered: false
       )
 
     cache_dir = Artefact.cache_dir()
 
-    Enum.flat_map(tasks, fn {:ok, {url, download}} ->
-      case download do
-        {:ok, body} ->
-          basename = basename_from_url(url)
-          path = Path.join(cache_dir, basename)
-          File.write!(path, body)
-          artefact = Artefact.checksum(basename, body)
+    Enum.flat_map(tasks, fn
+      {:ok, :checksum, url, artefact} ->
+        Mix.shell().info(
+          "NIF checksum file with checksum #{artefact.checksum} (#{artefact.checksum_algo})"
+        )
 
-          Mix.shell().info(
-            "NIF cached at #{path} with checksum #{artefact.checksum} (#{artefact.checksum_algo})"
-          )
+        [artefact]
 
-          [artefact]
+      {:ok, {:download, url, download}} ->
+        case download do
+          {:ok, body} ->
+            basename = basename_from_url(url)
+            path = Path.join(cache_dir, basename)
+            File.write!(path, body)
+            artefact = Artefact.checksum(basename, body)
 
-        result ->
-          if ignore_unavailable? do
-            msg = "Skipped unavailable NIF artifact. Reason: #{inspect(result)}"
-            Mix.shell().info(msg)
-          else
-            msg = "Could not finish the download of NIF artifacts. Reason: #{inspect(result)}"
-            Mix.shell().error(msg)
-          end
+            Mix.shell().info(
+              "NIF cached at #{path} with checksum #{artefact.checksum} (#{artefact.checksum_algo})"
+            )
 
-          []
-      end
+            [artefact]
+
+          result ->
+            if ignore_unavailable? do
+              msg = "Skipped unavailable NIF artifact. Reason: #{inspect(result)}"
+              Mix.shell().info(msg)
+            else
+              msg = "Could not finish the download of NIF artifacts. Reason: #{inspect(result)}"
+              Mix.shell().error(msg)
+            end
+
+            []
+        end
     end)
   end
 

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -48,6 +48,8 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
                 precompiler.post_precompile_target(target)
               end
 
+              Artefact.write_checksum_for_target!(precompiled_artefacts)
+
               precompiled_artefacts
 
             {:error, msg} ->


### PR DESCRIPTION
Hi this PR improves user experience by generating a checksum file for each target and assembling the final `checksum.exs` file using the generated checksum files over the actual binary files.

This can be useful because if the binaries need to be compiled in different CI runners, for example, separate runners for Linux, macOS and Windows, where we cannot produce the final `checksum.exs` right away on CI -- currently we have to download all precompiled binaries just to build the final `checksum.exs` file, and it costs disk space and time to do so especially when the binaries are huge. 

This feature is on by default but it requires users to include the generated `.sha256` files in the GitHub release. If the `.sha256` file cannot be downloaded (no matter it's because of a network error or it's missing in the GitHub release), the precompiled binaries will be downloaded to calculate the checksum (as what we're currently doing on the master branch).

In addition to that, this PR opens a chance for us to (maybe optionally) ditch away the `checksum.exs` file (somewhat a double edged sword), because it cannot be changed after it's released to hex.pm (IIRC it's 30 minutes or 1 hour-ish); so if the library author missed anything, they have to release a new version which means to go through the whole process again. 

Of course, one of the pros of using a `checksum.exs` file is that it prevents situations like network error or supply chain attacks (e.g., attackers re-upload these binaries with malicious code).