### PR TITLE
Support DragonFlyBSD

### DIFF
--- a/lib/elixir_make/compiler.ex
+++ b/lib/elixir_make/compiler.ex
@@ -141,7 +141,7 @@ defmodule ElixirMake.Compiler do
           true -> "nmake"
         end
 
-      {:unix, type} when type in [:freebsd, :openbsd, :netbsd] ->
+      {:unix, type} when type in [:freebsd, :openbsd, :netbsd, :dragonfly] ->
         "gmake"
 
       _ ->


### PR DESCRIPTION
[DragonFly][1] is a FreeBSD-derivative and like the other BSDs come with their own make ("bmake") - GNU make is available as "gmake".

[1]: www.dragonflybsd.org