### PR TITLE
Organize cached artefacts to simplify cleanup

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -16,7 +16,7 @@ defmodule ElixirMake.Artefact do
     cache_dir =
       Path.expand(
         System.get_env("ELIXIR_MAKE_CACHE_DIR") ||
-          :filename.basedir(:user_cache, "", cache_opts)
+          :filename.basedir(:user_cache, "elixir_make", cache_opts)
       )
 
     File.mkdir_p!(cache_dir)


### PR DESCRIPTION
This moves the default directory, `elixir_make`,  for storing downloaded
precompiled artefacts to a subdirectory in the user's cache directory so
that it's easier to know which files can be removed.
