### PR TITLE
support setting `:force_build` opts in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## v0.9.0-dev
 
   * Rely on certificate stores provided by Erlang/OTP 25+
+  * Support setting `:force_build` opts in config:
+
+    ```elixir
+    config :elixir_make, :force_build, app1: true, app2: false
+    ```
 
 ## v0.8.4 (2024-06-04)
 

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.Compile.ElixirMake do
 
     force_build =
       pre_release?(version) or Keyword.get(config, :make_force_build, false) or
-        Keyword.get(Application.get_env(:elixir_make, :force_build, []), app)
+        Keyword.get(Application.get_env(:elixir_make, :force_build, []), app, false)
 
     {precompiler_type, precompiler} = config[:make_precompiler] || {nil, nil}
 

--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -136,7 +136,11 @@ defmodule Mix.Tasks.Compile.ElixirMake do
     config = Mix.Project.config()
     app = config[:app]
     version = config[:version]
-    force_build = pre_release?(version) or Keyword.get(config, :make_force_build, false)
+
+    force_build =
+      pre_release?(version) or Keyword.get(config, :make_force_build, false) or
+        Keyword.get(Application.get_env(:elixir_make, :force_build, []), app)
+
     {precompiler_type, precompiler} = config[:make_precompiler] || {nil, nil}
 
     cond do


### PR DESCRIPTION
This PR adds support for setting a `:force_build` option in config, which specifies a keyword list with otp app name as the key and the corresponding value indicates if `elixir_make` should force the app to build locally.

```
[app1: true, app2: false]
```

Related discussion https://github.com/elixir-explorer/adbc/issues/109#issuecomment-2470179587.