### PR TITLE
Add :sunos to list of unix types that uses gmake

### DIFF
--- a/lib/elixir_make/compiler.ex
+++ b/lib/elixir_make/compiler.ex
@@ -147,7 +147,7 @@ defmodule ElixirMake.Compiler do
           true -> "nmake"
         end
 
-      {:unix, type} when type in [:freebsd, :openbsd, :netbsd, :dragonfly] ->
+      {:unix, type} when type in [:freebsd, :openbsd, :netbsd, :dragonfly, :sunos] ->
         "gmake"
 
       _ ->


### PR DESCRIPTION
When compiling under Solaris/Illumos and derivatives we also need to use `gmake`.