### PR TITLE
Fix warnings on 1.19

### DIFF
--- a/lib/elixir_make/artefact.ex
+++ b/lib/elixir_make/artefact.ex
@@ -1,7 +1,6 @@
 defmodule ElixirMake.Artefact do
   @moduledoc false
 
-  require Logger
   alias ElixirMake.Artefact
 
   @checksum_algo :sha256

--- a/lib/elixir_make/precompiler.ex
+++ b/lib/elixir_make/precompiler.ex
@@ -3,8 +3,6 @@ defmodule ElixirMake.Precompiler do
   The behaviour for precompiler modules.
   """
 
-  require Logger
-
   @typedoc """
   Target triplet.
   """

--- a/lib/mix/tasks/elixir_make.precompile.ex
+++ b/lib/mix/tasks/elixir_make.precompile.ex
@@ -13,7 +13,6 @@ defmodule Mix.Tasks.ElixirMake.Precompile do
   """
 
   alias ElixirMake.Artefact
-  require Logger
   use Mix.Task
 
   @recursive true

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule ElixirMake.Mixfile do
       package: package(),
       docs: docs(),
       deps: deps(),
-      xref: [exclude: [Mix, :crypto, :ssl, :public_key, :httpc]]
+      xref: [exclude: [Mix, :crypto, :ssl, :public_key, :httpc]],
+      test_ignore_filters: [~r|^test\/fixtures\/|]
     ]
   end
 


### PR DESCRIPTION
<img width="1672" height="956" alt="Screenshot 2025-10-04 at 20 58 36" src="https://github.com/user-attachments/assets/25141e99-986d-441f-a4ab-6621b7e44b37" />

I'm not sure if the `require Logger` are needed to support some old versions of Elixir? In which case, I could add `warn: false` instead.