### PR TITLE
CI housekeeping

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,4 @@
+# Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     strategy:
@@ -16,14 +16,14 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.9.4
-              otp: 20.3
+              elixir: "1.14"
+              otp: "25"
           - pair:
-              elixir: 1.13.4
-              otp: 24.3
+              elixir: "1.19"
+              otp: "28"
             lint: lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:

--- a/lib/elixir_make/downloader/httpc.ex
+++ b/lib/elixir_make/downloader/httpc.ex
@@ -67,13 +67,11 @@ defmodule ElixirMake.Downloader.Httpc do
   end
 
   defp otp_cacerts do
-    if System.otp_release() >= "25" do
-      # cacerts_get/0 raises if no certs found
-      try do
-        :public_key.cacerts_get()
-      rescue
-        _ -> nil
-      end
+    # cacerts_get/0 raises if no certs found
+    try do
+      :public_key.cacerts_get()
+    rescue
+      _ -> nil
     end
   end
 

--- a/lib/mix/tasks/elixir_make.checksum.ex
+++ b/lib/mix/tasks/elixir_make.checksum.ex
@@ -88,7 +88,9 @@ defmodule Mix.Tasks.ElixirMake.Checksum do
 
     if Keyword.get(options, :print, false) do
       artefacts
-      |> Enum.map(fn %Artefact{basename: basename, checksum: checksum} -> {basename, checksum} end)
+      |> Enum.map(fn %Artefact{basename: basename, checksum: checksum} ->
+        {basename, checksum}
+      end)
       |> Enum.sort()
       |> Enum.map_join("\n", fn {file, checksum} -> "#{checksum}  #{file}" end)
       |> IO.puts()

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ElixirMake.Mixfile do
     [
       app: :elixir_make,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.14",
       description: "A Make compiler for Mix",
       package: package(),
       docs: docs(),


### PR DESCRIPTION
List of changes:
- bump github actions
- bump minimum elixir from ~> 1.9 to ~> 1.14
- fix formatter config and formatting
- quote ci version numbers as yaml strings
- remove OTP 25 version guard in otp_cacerts/0
- support latest elixir/otp in ci matrix