### PR TITLE
Treat empty proxy env vars as unset

### DIFF
--- a/lib/elixir_make/downloader/httpc.ex
+++ b/lib/elixir_make/downloader/httpc.ex
@@ -12,14 +12,14 @@ defmodule ElixirMake.Downloader.Httpc do
     {:ok, _} = Application.ensure_all_started(:ssl)
     {:ok, _} = Application.ensure_all_started(:public_key)
 
-    if proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy") do
+    if proxy = proxy_env(:http) do
       Mix.shell().info("Using HTTP_PROXY: #{proxy}")
       %{host: host, port: port} = URI.parse(proxy)
 
       :httpc.set_options([{:proxy, {{String.to_charlist(host), port}, []}}])
     end
 
-    if proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy") do
+    if proxy = proxy_env(:https) do
       Mix.shell().info("Using HTTPS_PROXY: #{proxy}")
       %{host: host, port: port} = URI.parse(proxy)
       :httpc.set_options([{:https_proxy, {{String.to_charlist(host), port}, []}}])
@@ -72,6 +72,16 @@ defmodule ElixirMake.Downloader.Httpc do
       :public_key.cacerts_get()
     rescue
       _ -> nil
+    end
+  end
+
+  defp proxy_env(:http), do: get_env("HTTP_PROXY") || get_env("http_proxy")
+  defp proxy_env(:https), do: get_env("HTTPS_PROXY") || get_env("https_proxy")
+
+  defp get_env(var) do
+    case System.get_env(var) do
+      "" -> nil
+      value -> value
     end
   end
 


### PR DESCRIPTION
Closes #92

Empty/Blank string HTTP_PROXY/HTTPS_PROXY env vars are now treated as `nil`, preventing errors