### PR TITLE
Propagate download errors instead of falling back to a misleading file-not-found

### DIFF
--- a/lib/mix/tasks/compile.elixir_make.ex
+++ b/lib/mix/tasks/compile.elixir_make.ex
@@ -231,16 +231,20 @@ defmodule Mix.Tasks.Compile.ElixirMake do
       {:ok, target, nif_version_to_use, url} ->
         archived_fullpath = Artefact.archive_path(config, target, nif_version_to_use)
 
-        unless File.exists?(archived_fullpath) do
-          Mix.shell().info("Downloading precompiled NIF to #{archived_fullpath}")
+        download =
+          unless File.exists?(archived_fullpath) do
+            Mix.shell().info("Downloading precompiled NIF to #{archived_fullpath}")
 
-          with {:ok, archived_data} <- Artefact.download(config, url) do
-            File.mkdir_p(Path.dirname(archived_fullpath))
-            File.write(archived_fullpath, archived_data)
+            with {:ok, archived_data} <- Artefact.download(config, url) do
+              File.mkdir_p(Path.dirname(archived_fullpath))
+              File.write(archived_fullpath, archived_data)
+            end
           end
-        end
 
-        Artefact.verify_and_decompress(archived_fullpath, app_priv)
+        case download do
+          {:error, _} = error -> error
+          _ -> Artefact.verify_and_decompress(archived_fullpath, app_priv)
+        end
 
       {:error, msg} ->
         {:error, msg}

--- a/test/mix/tasks/compile.make_test.exs
+++ b/test/mix/tasks/compile.make_test.exs
@@ -421,6 +421,29 @@ defmodule Mix.Tasks.Compile.ElixirMakeTest do
     end)
   end
 
+  test "surfaces the download error instead of a misleading file-not-found" do
+    in_fixture(fn ->
+      File.mkdir!("priv")
+
+      File.write("Makefile", """
+      all:
+      \t@touch priv/my_app
+      """)
+
+      with_project_config(
+        [
+          make_precompiler: {:nif, MyApp.Precompiler},
+          make_precompiler_url: "https://example.com/@{artefact_filename}",
+          make_precompiler_downloader: MyApp.FailingDownloader
+        ],
+        fn ->
+          System.put_env("ELIXIR_MAKE_CACHE_DIR", "./cache")
+          assert capture_io(:stderr, fn -> run([]) end) =~ "download boom"
+        end
+      )
+    end)
+  end
+
   defp in_fixture(fun) do
     File.cd!(@fixture_project, fun)
   end
@@ -439,4 +462,11 @@ defmodule MyApp.Downloader do
     path = String.replace(url, "https://example.com/", __DIR__ <> "/dl/")
     File.read(path)
   end
+end
+
+defmodule MyApp.FailingDownloader do
+  @behaviour ElixirMake.Downloader
+
+  @impl true
+  def download(_url), do: {:error, "download boom"}
 end


### PR DESCRIPTION
Recently we were puzzled by an attempt to compile `lazy_html` library during an otherwise boring CI run, which never happened before. Upon closer look, it seems like it might have been a network hiccup.

This change improves the error message.

* before: when a precompiled NIF download fails, the error from `Artefact.download/2` was discarded and `verify_and_decompress/2` then ran on the missing file, reporting a misleading `:enoent` instead of the real reason.  
* after: capture the download result and report it before proceeding to compilation.